### PR TITLE
Add snapshot tests

### DIFF
--- a/tap-snapshots/test-index.spec.js-TAP.test.js
+++ b/tap-snapshots/test-index.spec.js-TAP.test.js
@@ -1,0 +1,86 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/index.spec.js TAP generate badge with { subject, status } > snapshot 1`] = `
+
+    <svg xmlns="http://www.w3.org/2000/svg" width="80.4" height="20">
+      <linearGradient id="a" x2="0" y2="100%">
+        <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+      </linearGradient>
+      <mask id="m"><rect width="80.4" height="20" rx="3" fill="#FFF"/></mask>
+      <g mask="url(#m)">
+        <rect width="34.9" height="20" fill="#555"/>
+        <rect x="34.9" width="45.5" height="20" fill="#08C"/>
+        <rect width="80.4" height="20" fill="url(#a)"/>
+      </g>
+      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="6.4" y="14.8" fill="#000" opacity="0.25">npm</text>
+        <text x="5.4" y="13.8">npm</text>
+        <text x="40.4" y="14.8" fill="#000" opacity="0.25" textLength="35.5">v1.0.0</text>
+        <text x="39.4" y="13.8" textLength="35.5">v1.0.0</text>
+      </g>
+    </svg>
+  
+`
+
+exports[`test/index.spec.js TAP generate badge with { subject, status, color } > snapshot 1`] = `
+
+    <svg xmlns="http://www.w3.org/2000/svg" width="80.4" height="20">
+      <linearGradient id="a" x2="0" y2="100%">
+        <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+      </linearGradient>
+      <mask id="m"><rect width="80.4" height="20" rx="3" fill="#FFF"/></mask>
+      <g mask="url(#m)">
+        <rect width="34.9" height="20" fill="#555"/>
+        <rect x="34.9" width="45.5" height="20" fill="#ADF"/>
+        <rect width="80.4" height="20" fill="url(#a)"/>
+      </g>
+      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="6.4" y="14.8" fill="#000" opacity="0.25">npm</text>
+        <text x="5.4" y="13.8">npm</text>
+        <text x="40.4" y="14.8" fill="#000" opacity="0.25" textLength="35.5">v1.0.0</text>
+        <text x="39.4" y="13.8" textLength="35.5">v1.0.0</text>
+      </g>
+    </svg>
+  
+`
+
+exports[`test/index.spec.js TAP generate badge with { subject, status, style } > snapshot 1`] = `
+
+      <svg xmlns="http://www.w3.org/2000/svg" width="80.4" height="20">
+        <g>
+          <rect width="34.9" height="20" fill="#555"/>
+          <rect x="34.9" width="45.5" height="20" fill="#08C"/>
+        </g>
+        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+          <text x="6.1" y="14.8" fill="#000" opacity="0.1">npm</text>
+          <text x="5.1" y="13.8">npm</text>
+          <text x="40.4" y="14.8" fill="#000" opacity="0.1" textLength="35.5">v1.0.0</text>
+          <text x="39.4" y="13.8" textLength="35.5">v1.0.0</text>
+        </g>
+      </svg>
+    
+`
+
+exports[`test/index.spec.js TAP generate badge with { subject, status, color, style } > snapshot 1`] = `
+
+      <svg xmlns="http://www.w3.org/2000/svg" width="80.4" height="20">
+        <g>
+          <rect width="34.9" height="20" fill="#555"/>
+          <rect x="34.9" width="45.5" height="20" fill="#ADF"/>
+        </g>
+        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+          <text x="6.1" y="14.8" fill="#000" opacity="0.1">npm</text>
+          <text x="5.1" y="13.8">npm</text>
+          <text x="40.4" y="14.8" fill="#000" opacity="0.1" textLength="35.5">v1.0.0</text>
+          <text x="39.4" y="13.8" textLength="35.5">v1.0.0</text>
+        </g>
+      </svg>
+    
+`

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,23 +4,27 @@ const badgen = require('..')
 tap.test('generate badge with { subject, status }', t => {
   const svg = badgen({ subject: 'npm', status: 'v1.0.0' })
   t.ok(typeof svg === 'string', 'successfully generated')
+  t.matchSnapshot(svg, 'snapshot')
   t.end()
 })
 
 tap.test('generate badge with { subject, status, color }', t => {
   const svg = badgen({ subject: 'npm', status: 'v1.0.0', color: 'ADF' })
   t.ok(typeof svg === 'string', 'successfully generated')
+  t.matchSnapshot(svg, 'snapshot')
   t.end()
 })
 
 tap.test('generate badge with { subject, status, style }', t => {
   const svg = badgen({ subject: 'npm', status: 'v1.0.0', style: 'flat' })
   t.ok(typeof svg === 'string', 'successfully generated')
+  t.matchSnapshot(svg, 'snapshot')
   t.end()
 })
 
 tap.test('generate badge with { subject, status, color, style }', t => {
   const svg = badgen({ subject: 'npm', status: 'v1.0.0', color: 'ADF', style: 'flat' })
   t.ok(typeof svg === 'string', 'successfully generated')
+  t.matchSnapshot(svg, 'snapshot')
   t.end()
 })


### PR DESCRIPTION
I noticed this test can be improved with snapshot tests per https://www.node-tap.org/snapshots/ 
🤓 

After merge you can add newer emoji snapshots by running
```
TAP_SNAPSHOT=1 npm test
```