### PR TITLE
refactor: optimize svg output

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -2,10 +2,7 @@ const { Suite } = require('benchmark')
 const badgen = require('..')
 const dockerIcon = require('../test/docker-icon-b64.js')
 
-const longParams = {
-  subject: 'build-build-build',
-  status: 'passing-passing-passing'
-}
+const longParams = { subject: 'build-build-build', status: 'passing-passing-passing' }
 const fullParams = { subject: 'license', status: 'Apache 2.0', color: 'cyan' }
 const emojiParams = { subject: 'emojis', status: '💩🤱🦄💩🤱🦄', emoji: true }
 const iconParams = { subject: 'docker', status: 'badge', icon: dockerIcon }
@@ -17,5 +14,7 @@ new Suite()
   .add('   [flat] style, full params', () => badgen({ style: 'flat', ...fullParams }))
   .add('[classic] style, with emoji ', () => badgen(emojiParams))
   .add('[classic] style, with icon  ', () => badgen(iconParams))
+  .add('   [flat] style, with emoji ', () => badgen({ style: 'flat', ...emojiParams }))
+  .add('   [flat] style, with icon  ', () => badgen({ style: 'flat', ...iconParams }))
   .on('cycle', event => console.log(String(event.target)))
   .run()

--- a/lib/calc-text-width.js
+++ b/lib/calc-text-width.js
@@ -1,10 +1,10 @@
+const round = require('./round')
 const widthsVerdana11 = require('./widths-verdana-11.json')
 const astralRegex = require('unicode-astral-regex')
 
 const calcWidth = (charWidthTable) => {
-  const SCALE = 10 // Prevent results like 60.599999999999994
-  const widthTable = charWidthTable.map(w => Math.round(w * SCALE))
-  widthTable[64] = widthTable[64] + 6 // Slightly increase width of "@" by 0.6px
+  const widthTable = charWidthTable.map(w => round(w))
+  widthTable[64] = widthTable[64] + 0.6 // Slightly increase width of "@" by 0.6px
 
   return (text, astral) => {
     if (astral) text = text.match(astralRegex) || []
@@ -16,7 +16,7 @@ const calcWidth = (charWidthTable) => {
       code = text[i].charCodeAt()
       total += widthTable[code < 127 ? code : 64] // Width as "@" for overflows
     }
-    return total / SCALE
+    return total
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
-const calcWidth = require('./calc-text-width.js').Verdana11
-const colorPresets = require('./color-presets.js')
+const calcWidth = require('./calc-text-width').Verdana11
+const colorPresets = require('./color-presets')
+const round = require('./round')
 
 module.exports = ({ subject, status, color, style, emoji, icon, iconWidth = 13 }) => {
   typeAssert(typeof subject === 'string', '<subject> must be string')
@@ -9,8 +10,8 @@ module.exports = ({ subject, status, color, style, emoji, icon, iconWidth = 13 }
   const iconSpanWidth = icon ? (subject.length ? iconWidth + 4 : iconWidth - 2) : 0
   const sbTextWidth = calcWidth(subject, emoji)
   const stTextWidth = calcWidth(status, emoji)
-  const sbRectWidth = sbTextWidth + 10.2 + iconSpanWidth
-  const stRectWidth = stTextWidth + 10
+  const sbRectWidth = round(sbTextWidth + 10.2 + iconSpanWidth)
+  const stRectWidth = round(stTextWidth + 10)
   const width = sbRectWidth + stRectWidth
 
   if (style === 'flat') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,18 +17,16 @@ module.exports = ({ subject, status, color, style, emoji, icon, iconWidth = 13 }
 
   if (style === 'flat') {
     return `
-        <g>
-          <rect width="${sbRectWidth}" height="20" fill="#555"/>
-          <rect x="${sbRectWidth}" width="${stRectWidth}" height="20" fill="#${color}"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-          <text x="${icon ? '22.5' : '6.3'}" y="14.8" textLength="${sbTextWidth}" fill="#000" opacity="0.1">${subject}</text>
       <svg width="${width}" height="20" xmlns="http://www.w3.org/2000/svg"${xlink}>
+        <path fill="#555" d="M0 0h${sbRectWidth}v20H0z"/>
+        <path fill="#${color}" d="M${sbRectWidth} 0h${stRectWidth}v20H${sbRectWidth}z"/>
+        <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+          <text x="${icon ? '22.5' : '6.3'}" y="14.8" textLength="${sbTextWidth}" fill="#000" opacity=".1">${subject}</text>
           <text x="${icon ? '21.5' : '5.3'}" y="13.8" textLength="${sbTextWidth}">${subject}</text>
-          <text x="${sbRectWidth + 5.5}" y="14.8" fill="#000" opacity="0.1" textLength="${stTextWidth}">${status}</text>
+          <text x="${sbRectWidth + 5.5}" y="14.8" textLength="${stTextWidth}" fill="#000" opacity=".1">${status}</text>
           <text x="${sbRectWidth + 4.5}" y="13.8" textLength="${stTextWidth}">${status}</text>
         </g>
-        ${icon ? `<image x="3.8" y="3.4" width="${iconWidth}" height="13.2" xlink:href="${icon}"/>` : ''}
+        ${icon ? `<image width="${iconWidth}" height="13.2" x="3.8" y="3.4" xlink:href="${icon}"/>` : ''}
       </svg>
     `
   }
@@ -39,19 +37,19 @@ module.exports = ({ subject, status, color, style, emoji, icon, iconWidth = 13 }
         <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
       </linearGradient>
-      <mask id="m"><rect width="${width}" height="20" rx="3" fill="#FFF"/></mask>
+      <mask id="m"><rect width="${width}" height="20" fill="#FFF" rx="3"/></mask>
       <g mask="url(#m)">
-        <rect width="${sbRectWidth}" height="20" fill="#555"/>
-        <rect x="${sbRectWidth}" width="${stRectWidth}" height="20" fill="#${color}"/>
-        <rect width="${width}" height="20" fill="url(#a)"/>
+        <path fill="#555" d="M0 0h${sbRectWidth}v20H0z"/>
+        <path fill="#${color}" d="M${sbRectWidth} 0h${stRectWidth}v20H${sbRectWidth}z"/>
+        <path fill="url(#a)" d="M0 0h${width}v20H0z"/>
       </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-        <text x="${icon ? '22.5' : '6.5'}" y="14.8" textLength="${sbTextWidth}" fill="#000" opacity="0.25">${subject}</text>
+      <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="${icon ? '22.5' : '6.5'}" y="14.8" textLength="${sbTextWidth}" fill="#000" opacity=".25">${subject}</text>
         <text x="${icon ? '21.5' : '5.5'}" y="13.8" textLength="${sbTextWidth}">${subject}</text>
-        <text x="${sbRectWidth + 5.5}" y="14.8" fill="#000" opacity="0.25" textLength="${stTextWidth}">${status}</text>
+        <text x="${sbRectWidth + 5.5}" y="14.8" textLength="${stTextWidth}" fill="#000" opacity=".25">${status}</text>
         <text x="${sbRectWidth + 4.5}" y="13.8" textLength="${stTextWidth}">${status}</text>
       </g>
-      ${icon ? `<image x="3.9" y="3.5" width="${iconWidth}" height="13" xlink:href="${icon}"/>` : ''}
+      ${icon ? `<image width="${iconWidth}" height="13" x="3.9" y="3.5" xlink:href="${icon}"/>` : ''}
     </svg>
   `
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,16 +13,17 @@ module.exports = ({ subject, status, color, style, emoji, icon, iconWidth = 13 }
   const sbRectWidth = round(sbTextWidth + 10.2 + iconSpanWidth)
   const stRectWidth = round(stTextWidth + 10)
   const width = sbRectWidth + stRectWidth
+  const xlink = icon ? ' xmlns:xlink="http://www.w3.org/1999/xlink"' : ''
 
   if (style === 'flat') {
     return `
-      <svg width="${width}" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <g>
           <rect width="${sbRectWidth}" height="20" fill="#555"/>
           <rect x="${sbRectWidth}" width="${stRectWidth}" height="20" fill="#${color}"/>
         </g>
         <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
           <text x="${icon ? '22.5' : '6.3'}" y="14.8" textLength="${sbTextWidth}" fill="#000" opacity="0.1">${subject}</text>
+      <svg width="${width}" height="20" xmlns="http://www.w3.org/2000/svg"${xlink}>
           <text x="${icon ? '21.5' : '5.3'}" y="13.8" textLength="${sbTextWidth}">${subject}</text>
           <text x="${sbRectWidth + 5.5}" y="14.8" fill="#000" opacity="0.1" textLength="${stTextWidth}">${status}</text>
           <text x="${sbRectWidth + 4.5}" y="13.8" textLength="${stTextWidth}">${status}</text>
@@ -33,7 +34,7 @@ module.exports = ({ subject, status, color, style, emoji, icon, iconWidth = 13 }
   }
 
   return `
-    <svg width="${width}" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <svg width="${width}" height="20" xmlns="http://www.w3.org/2000/svg"${xlink}>
       <linearGradient id="a" x2="0" y2="100%">
         <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>

--- a/lib/round.js
+++ b/lib/round.js
@@ -1,0 +1,2 @@
+// Converts results like 60.599999999999994 to 60.6
+module.exports = value => Math.round(value * 10) / 10

--- a/tap-snapshots/test-index.spec.js-TAP.test.js
+++ b/tap-snapshots/test-index.spec.js-TAP.test.js
@@ -7,22 +7,22 @@
 'use strict'
 exports[`test/index.spec.js TAP generate badge with { subject, status } > snapshot 1`] = `
 
-    <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg">
       <linearGradient id="a" x2="0" y2="100%">
         <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
       </linearGradient>
-      <mask id="m"><rect width="80.6" height="20" rx="3" fill="#FFF"/></mask>
+      <mask id="m"><rect width="80.6" height="20" fill="#FFF" rx="3"/></mask>
       <g mask="url(#m)">
-        <rect width="35.099999999999994" height="20" fill="#555"/>
-        <rect x="35.099999999999994" width="45.5" height="20" fill="#08C"/>
-        <rect width="80.6" height="20" fill="url(#a)"/>
+        <path fill="#555" d="M0 0h35.1v20H0z"/>
+        <path fill="#08C" d="M35.1 0h45.5v20H35.1z"/>
+        <path fill="url(#a)" d="M0 0h80.6v20H0z"/>
       </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-        <text x="6.5" y="14.8" textLength="24.9" fill="#000" opacity="0.25">npm</text>
+      <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="6.5" y="14.8" textLength="24.9" fill="#000" opacity=".25">npm</text>
         <text x="5.5" y="13.8" textLength="24.9">npm</text>
-        <text x="40.599999999999994" y="14.8" fill="#000" opacity="0.25" textLength="35.5">v1.0.0</text>
-        <text x="39.599999999999994" y="13.8" textLength="35.5">v1.0.0</text>
+        <text x="40.6" y="14.8" textLength="35.5" fill="#000" opacity=".25">v1.0.0</text>
+        <text x="39.6" y="13.8" textLength="35.5">v1.0.0</text>
       </g>
       
     </svg>
@@ -31,22 +31,22 @@ exports[`test/index.spec.js TAP generate badge with { subject, status } > snapsh
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, color } > snapshot 1`] = `
 
-    <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg">
       <linearGradient id="a" x2="0" y2="100%">
         <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
       </linearGradient>
-      <mask id="m"><rect width="80.6" height="20" rx="3" fill="#FFF"/></mask>
+      <mask id="m"><rect width="80.6" height="20" fill="#FFF" rx="3"/></mask>
       <g mask="url(#m)">
-        <rect width="35.099999999999994" height="20" fill="#555"/>
-        <rect x="35.099999999999994" width="45.5" height="20" fill="#ADF"/>
-        <rect width="80.6" height="20" fill="url(#a)"/>
+        <path fill="#555" d="M0 0h35.1v20H0z"/>
+        <path fill="#ADF" d="M35.1 0h45.5v20H35.1z"/>
+        <path fill="url(#a)" d="M0 0h80.6v20H0z"/>
       </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-        <text x="6.5" y="14.8" textLength="24.9" fill="#000" opacity="0.25">npm</text>
+      <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="6.5" y="14.8" textLength="24.9" fill="#000" opacity=".25">npm</text>
         <text x="5.5" y="13.8" textLength="24.9">npm</text>
-        <text x="40.599999999999994" y="14.8" fill="#000" opacity="0.25" textLength="35.5">v1.0.0</text>
-        <text x="39.599999999999994" y="13.8" textLength="35.5">v1.0.0</text>
+        <text x="40.6" y="14.8" textLength="35.5" fill="#000" opacity=".25">v1.0.0</text>
+        <text x="39.6" y="13.8" textLength="35.5">v1.0.0</text>
       </g>
       
     </svg>
@@ -55,16 +55,14 @@ exports[`test/index.spec.js TAP generate badge with { subject, status, color } >
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, style } > snapshot 1`] = `
 
-      <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <g>
-          <rect width="35.099999999999994" height="20" fill="#555"/>
-          <rect x="35.099999999999994" width="45.5" height="20" fill="#08C"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-          <text x="6.3" y="14.8" textLength="24.9" fill="#000" opacity="0.1">npm</text>
+      <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg">
+        <path fill="#555" d="M0 0h35.1v20H0z"/>
+        <path fill="#08C" d="M35.1 0h45.5v20H35.1z"/>
+        <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+          <text x="6.3" y="14.8" textLength="24.9" fill="#000" opacity=".1">npm</text>
           <text x="5.3" y="13.8" textLength="24.9">npm</text>
-          <text x="40.599999999999994" y="14.8" fill="#000" opacity="0.1" textLength="35.5">v1.0.0</text>
-          <text x="39.599999999999994" y="13.8" textLength="35.5">v1.0.0</text>
+          <text x="40.6" y="14.8" textLength="35.5" fill="#000" opacity=".1">v1.0.0</text>
+          <text x="39.6" y="13.8" textLength="35.5">v1.0.0</text>
         </g>
         
       </svg>
@@ -73,16 +71,14 @@ exports[`test/index.spec.js TAP generate badge with { subject, status, style } >
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, color, style } > snapshot 1`] = `
 
-      <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <g>
-          <rect width="35.099999999999994" height="20" fill="#555"/>
-          <rect x="35.099999999999994" width="45.5" height="20" fill="#ADF"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-          <text x="6.3" y="14.8" textLength="24.9" fill="#000" opacity="0.1">npm</text>
+      <svg width="80.6" height="20" xmlns="http://www.w3.org/2000/svg">
+        <path fill="#555" d="M0 0h35.1v20H0z"/>
+        <path fill="#ADF" d="M35.1 0h45.5v20H35.1z"/>
+        <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+          <text x="6.3" y="14.8" textLength="24.9" fill="#000" opacity=".1">npm</text>
           <text x="5.3" y="13.8" textLength="24.9">npm</text>
-          <text x="40.599999999999994" y="14.8" fill="#000" opacity="0.1" textLength="35.5">v1.0.0</text>
-          <text x="39.599999999999994" y="13.8" textLength="35.5">v1.0.0</text>
+          <text x="40.6" y="14.8" textLength="35.5" fill="#000" opacity=".1">v1.0.0</text>
+          <text x="39.6" y="13.8" textLength="35.5">v1.0.0</text>
         </g>
         
       </svg>
@@ -96,19 +92,19 @@ exports[`test/index.spec.js TAP generate badge with { subject, status, icon } > 
         <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
       </linearGradient>
-      <mask id="m"><rect width="96.69999999999999" height="20" rx="3" fill="#FFF"/></mask>
+      <mask id="m"><rect width="96.69999999999999" height="20" fill="#FFF" rx="3"/></mask>
       <g mask="url(#m)">
-        <rect width="64.3" height="20" fill="#555"/>
-        <rect x="64.3" width="32.4" height="20" fill="#08C"/>
-        <rect width="96.69999999999999" height="20" fill="url(#a)"/>
+        <path fill="#555" d="M0 0h64.3v20H0z"/>
+        <path fill="#08C" d="M64.3 0h32.4v20H64.3z"/>
+        <path fill="url(#a)" d="M0 0h96.69999999999999v20H0z"/>
       </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-        <text x="22.5" y="14.8" textLength="37.1" fill="#000" opacity="0.25">docker</text>
+      <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="22.5" y="14.8" textLength="37.1" fill="#000" opacity=".25">docker</text>
         <text x="21.5" y="13.8" textLength="37.1">docker</text>
-        <text x="69.8" y="14.8" fill="#000" opacity="0.25" textLength="22.4">icon</text>
+        <text x="69.8" y="14.8" textLength="22.4" fill="#000" opacity=".25">icon</text>
         <text x="68.8" y="13.8" textLength="22.4">icon</text>
       </g>
-      <image x="3.9" y="3.5" width="13" height="13" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTg5IiB3aWR0aD0iMjIxLjY2NyI+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBkPSJNMCAxNDEuNzVoMTY2LjI1VjBIMHoiLz48L2NsaXBQYXRoPjxjbGlwUGF0aCBpZD0iYiI+PHBhdGggZD0iTTAgMTQxLjc1aDE2Ni4yNVYwSDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzIDAgMCAtMS4zMzMzMyAwIDE4OSkiPjxwYXRoIGQ9Ik05NC4yNjggNzYuMjA0aDE1Ljc0M3YxNC4zMTJIOTQuMjY4em0tMTguNjA1IDBoMTUuNzQydjE0LjMxMkg3NS42NjN6bS0xOC42MDUgMGgxNS43NDN2MTQuMzEySDU3LjA1OHptLTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTJIMzguNDUzem0tMTguNjA1IDBoMTUuNzQzdjE0LjMxMkgxOS44NDh6bTE4LjYwNSAxNy4xNzNoMTUuNzQzdjE0LjMxMUgzOC40NTN6bTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTFINTcuMDU4em0xOC42MDUgMGgxNS43NDJ2MTQuMzExSDc1LjY2M3ptMCAxNy4xNzRoMTUuNzQydjE0LjMxMkg3NS42NjN6bTgxLjY1OC0yNi4wMDNjLTMuNDM4IDIuMy0xMS4zMzggMy4xNDMtMTcuNDE3IDEuOTk3LS43ODMgNS43MjYtMy45NzQgMTAuNjkxLTkuNzc5IDE1LjE3OWwtMy4zMzcgMi4yMjUtMi4yMjctMy4zNGMtMi44NTEtNC4yOTktNC4yNzUtMTAuMjU2LTMuODA4LTE1Ljk2Ny4yMS0yLjAxLjg3LTUuNjAzIDIuOTM3LTguNzY0LTIuMDY2LTEuMTEtNi4xNS0yLjY0LTExLjUzMy0yLjUzN0g4LjYyMmwtLjIwMy0xLjE5MmMtLjk3My01Ljc0LS45NTItMjMuNjUzIDEwLjY3OC0zNy40MiA4Ljg0LTEwLjQ2NCAyMi4wOTQtMTUuNzcyIDM5LjM5Mi0xNS43NzIgMzcuNSAwIDY1LjI0NCAxNy4yNjMgNzguMjM3IDQ4LjY0MSA1LjEwOS0uMTAyIDE2LjEwOS0uMDMgMjEuNzYgMTAuNzY2LjE0Ny4yNDguNDg2Ljg5NiAxLjQ3MyAyLjk0MmwuNTQxIDEuMTIyeiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9nPjxnIGNsaXAtcGF0aD0idXJsKCNiKSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4zMzMzMyAwIDAgLTEuMzMzMzMgMCAxODkpIj48cGF0aCBkPSJNMTA0LjEzNyAyNC4yNDFoLjIxNmMuMjUyIDAgLjQ1Ni4wODQuNDU2LjI4OCAwIC4xOC0uMTMyLjMtLjQyLjMtLjEyIDAtLjIwNC0uMDEyLS4yNTItLjAyNHptLS4wMTItMS4xMTVoLS40NTZ2MS45NjdjLjE4LjAzNi40MzIuMDYuNzU2LjA2LjM3MiAwIC41MzktLjA2LjY4NC0uMTQ0YS41NDcuNTQ3IDAgMCAwIC4xOS0uNDMyYzAtLjIxNi0uMTY3LS4zODQtLjQwNi0uNDU1di0uMDI1Yy4xOS0uMDcyLjMtLjIxNS4zNTktLjQ3OS4wNi0uMy4wOTYtLjQyLjE0NS0uNDkyaC0uNDkyYy0uMDYuMDcyLS4wOTYuMjUyLS4xNTcuNDgtLjAzNS4yMTYtLjE1NS4zMTItLjQwNy4zMTJoLS4yMTZ6bS0xLjIxMiAxLjAzMmMwLS44NzYuNjQ5LTEuNTcgMS41MzYtMS41Ny44NjQgMCAxLjQ5OS42OTQgMS40OTkgMS41NTcgMCAuODc2LS42MzUgMS41ODMtMS41MTEgMS41ODMtLjg3NSAwLTEuNTI0LS43MDctMS41MjQtMS41N20zLjUzOCAwYzAtMS4xMTYtLjg3NS0xLjk5LTIuMDE0LTEuOTktMS4xMjcgMC0yLjAyNy44NzQtMi4wMjcgMS45OSAwIDEuMDkxLjkgMS45NjcgMi4wMjcgMS45NjcgMS4xMzkgMCAyLjAxNC0uODc2IDIuMDE0LTEuOTY3IiBmaWxsPSIjZmZmZmZmIi8+PC9nPjwvc3ZnPgo="/>
+      <image width="13" height="13" x="3.9" y="3.5" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTg5IiB3aWR0aD0iMjIxLjY2NyI+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBkPSJNMCAxNDEuNzVoMTY2LjI1VjBIMHoiLz48L2NsaXBQYXRoPjxjbGlwUGF0aCBpZD0iYiI+PHBhdGggZD0iTTAgMTQxLjc1aDE2Ni4yNVYwSDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzIDAgMCAtMS4zMzMzMyAwIDE4OSkiPjxwYXRoIGQ9Ik05NC4yNjggNzYuMjA0aDE1Ljc0M3YxNC4zMTJIOTQuMjY4em0tMTguNjA1IDBoMTUuNzQydjE0LjMxMkg3NS42NjN6bS0xOC42MDUgMGgxNS43NDN2MTQuMzEySDU3LjA1OHptLTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTJIMzguNDUzem0tMTguNjA1IDBoMTUuNzQzdjE0LjMxMkgxOS44NDh6bTE4LjYwNSAxNy4xNzNoMTUuNzQzdjE0LjMxMUgzOC40NTN6bTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTFINTcuMDU4em0xOC42MDUgMGgxNS43NDJ2MTQuMzExSDc1LjY2M3ptMCAxNy4xNzRoMTUuNzQydjE0LjMxMkg3NS42NjN6bTgxLjY1OC0yNi4wMDNjLTMuNDM4IDIuMy0xMS4zMzggMy4xNDMtMTcuNDE3IDEuOTk3LS43ODMgNS43MjYtMy45NzQgMTAuNjkxLTkuNzc5IDE1LjE3OWwtMy4zMzcgMi4yMjUtMi4yMjctMy4zNGMtMi44NTEtNC4yOTktNC4yNzUtMTAuMjU2LTMuODA4LTE1Ljk2Ny4yMS0yLjAxLjg3LTUuNjAzIDIuOTM3LTguNzY0LTIuMDY2LTEuMTEtNi4xNS0yLjY0LTExLjUzMy0yLjUzN0g4LjYyMmwtLjIwMy0xLjE5MmMtLjk3My01Ljc0LS45NTItMjMuNjUzIDEwLjY3OC0zNy40MiA4Ljg0LTEwLjQ2NCAyMi4wOTQtMTUuNzcyIDM5LjM5Mi0xNS43NzIgMzcuNSAwIDY1LjI0NCAxNy4yNjMgNzguMjM3IDQ4LjY0MSA1LjEwOS0uMTAyIDE2LjEwOS0uMDMgMjEuNzYgMTAuNzY2LjE0Ny4yNDguNDg2Ljg5NiAxLjQ3MyAyLjk0MmwuNTQxIDEuMTIyeiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9nPjxnIGNsaXAtcGF0aD0idXJsKCNiKSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4zMzMzMyAwIDAgLTEuMzMzMzMgMCAxODkpIj48cGF0aCBkPSJNMTA0LjEzNyAyNC4yNDFoLjIxNmMuMjUyIDAgLjQ1Ni4wODQuNDU2LjI4OCAwIC4xOC0uMTMyLjMtLjQyLjMtLjEyIDAtLjIwNC0uMDEyLS4yNTItLjAyNHptLS4wMTItMS4xMTVoLS40NTZ2MS45NjdjLjE4LjAzNi40MzIuMDYuNzU2LjA2LjM3MiAwIC41MzktLjA2LjY4NC0uMTQ0YS41NDcuNTQ3IDAgMCAwIC4xOS0uNDMyYzAtLjIxNi0uMTY3LS4zODQtLjQwNi0uNDU1di0uMDI1Yy4xOS0uMDcyLjMtLjIxNS4zNTktLjQ3OS4wNi0uMy4wOTYtLjQyLjE0NS0uNDkyaC0uNDkyYy0uMDYuMDcyLS4wOTYuMjUyLS4xNTcuNDgtLjAzNS4yMTYtLjE1NS4zMTItLjQwNy4zMTJoLS4yMTZ6bS0xLjIxMiAxLjAzMmMwLS44NzYuNjQ5LTEuNTcgMS41MzYtMS41Ny44NjQgMCAxLjQ5OS42OTQgMS40OTkgMS41NTcgMCAuODc2LS42MzUgMS41ODMtMS41MTEgMS41ODMtLjg3NSAwLTEuNTI0LS43MDctMS41MjQtMS41N20zLjUzOCAwYzAtMS4xMTYtLjg3NS0xLjk5LTIuMDE0LTEuOTktMS4xMjcgMC0yLjAyNy44NzQtMi4wMjcgMS45OSAwIDEuMDkxLjkgMS45NjcgMi4wMjcgMS45NjcgMS4xMzkgMCAyLjAxNC0uODc2IDIuMDE0LTEuOTY3IiBmaWxsPSIjZmZmZmZmIi8+PC9nPjwvc3ZnPgo="/>
     </svg>
   
 `
@@ -120,19 +116,19 @@ exports[`test/index.spec.js TAP generate badge with { status, icon } > snapshot 
         <stop offset="0" stop-color="#EEE" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
       </linearGradient>
-      <mask id="m"><rect width="53.599999999999994" height="20" rx="3" fill="#FFF"/></mask>
+      <mask id="m"><rect width="53.599999999999994" height="20" fill="#FFF" rx="3"/></mask>
       <g mask="url(#m)">
-        <rect width="21.2" height="20" fill="#555"/>
-        <rect x="21.2" width="32.4" height="20" fill="#08C"/>
-        <rect width="53.599999999999994" height="20" fill="url(#a)"/>
+        <path fill="#555" d="M0 0h21.2v20H0z"/>
+        <path fill="#08C" d="M21.2 0h32.4v20H21.2z"/>
+        <path fill="url(#a)" d="M0 0h53.599999999999994v20H0z"/>
       </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-        <text x="22.5" y="14.8" textLength="0" fill="#000" opacity="0.25"></text>
+      <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+        <text x="22.5" y="14.8" textLength="0" fill="#000" opacity=".25"></text>
         <text x="21.5" y="13.8" textLength="0"></text>
-        <text x="26.7" y="14.8" fill="#000" opacity="0.25" textLength="22.4">icon</text>
+        <text x="26.7" y="14.8" textLength="22.4" fill="#000" opacity=".25">icon</text>
         <text x="25.7" y="13.8" textLength="22.4">icon</text>
       </g>
-      <image x="3.9" y="3.5" width="13" height="13" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTg5IiB3aWR0aD0iMjIxLjY2NyI+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBkPSJNMCAxNDEuNzVoMTY2LjI1VjBIMHoiLz48L2NsaXBQYXRoPjxjbGlwUGF0aCBpZD0iYiI+PHBhdGggZD0iTTAgMTQxLjc1aDE2Ni4yNVYwSDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzIDAgMCAtMS4zMzMzMyAwIDE4OSkiPjxwYXRoIGQ9Ik05NC4yNjggNzYuMjA0aDE1Ljc0M3YxNC4zMTJIOTQuMjY4em0tMTguNjA1IDBoMTUuNzQydjE0LjMxMkg3NS42NjN6bS0xOC42MDUgMGgxNS43NDN2MTQuMzEySDU3LjA1OHptLTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTJIMzguNDUzem0tMTguNjA1IDBoMTUuNzQzdjE0LjMxMkgxOS44NDh6bTE4LjYwNSAxNy4xNzNoMTUuNzQzdjE0LjMxMUgzOC40NTN6bTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTFINTcuMDU4em0xOC42MDUgMGgxNS43NDJ2MTQuMzExSDc1LjY2M3ptMCAxNy4xNzRoMTUuNzQydjE0LjMxMkg3NS42NjN6bTgxLjY1OC0yNi4wMDNjLTMuNDM4IDIuMy0xMS4zMzggMy4xNDMtMTcuNDE3IDEuOTk3LS43ODMgNS43MjYtMy45NzQgMTAuNjkxLTkuNzc5IDE1LjE3OWwtMy4zMzcgMi4yMjUtMi4yMjctMy4zNGMtMi44NTEtNC4yOTktNC4yNzUtMTAuMjU2LTMuODA4LTE1Ljk2Ny4yMS0yLjAxLjg3LTUuNjAzIDIuOTM3LTguNzY0LTIuMDY2LTEuMTEtNi4xNS0yLjY0LTExLjUzMy0yLjUzN0g4LjYyMmwtLjIwMy0xLjE5MmMtLjk3My01Ljc0LS45NTItMjMuNjUzIDEwLjY3OC0zNy40MiA4Ljg0LTEwLjQ2NCAyMi4wOTQtMTUuNzcyIDM5LjM5Mi0xNS43NzIgMzcuNSAwIDY1LjI0NCAxNy4yNjMgNzguMjM3IDQ4LjY0MSA1LjEwOS0uMTAyIDE2LjEwOS0uMDMgMjEuNzYgMTAuNzY2LjE0Ny4yNDguNDg2Ljg5NiAxLjQ3MyAyLjk0MmwuNTQxIDEuMTIyeiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9nPjxnIGNsaXAtcGF0aD0idXJsKCNiKSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4zMzMzMyAwIDAgLTEuMzMzMzMgMCAxODkpIj48cGF0aCBkPSJNMTA0LjEzNyAyNC4yNDFoLjIxNmMuMjUyIDAgLjQ1Ni4wODQuNDU2LjI4OCAwIC4xOC0uMTMyLjMtLjQyLjMtLjEyIDAtLjIwNC0uMDEyLS4yNTItLjAyNHptLS4wMTItMS4xMTVoLS40NTZ2MS45NjdjLjE4LjAzNi40MzIuMDYuNzU2LjA2LjM3MiAwIC41MzktLjA2LjY4NC0uMTQ0YS41NDcuNTQ3IDAgMCAwIC4xOS0uNDMyYzAtLjIxNi0uMTY3LS4zODQtLjQwNi0uNDU1di0uMDI1Yy4xOS0uMDcyLjMtLjIxNS4zNTktLjQ3OS4wNi0uMy4wOTYtLjQyLjE0NS0uNDkyaC0uNDkyYy0uMDYuMDcyLS4wOTYuMjUyLS4xNTcuNDgtLjAzNS4yMTYtLjE1NS4zMTItLjQwNy4zMTJoLS4yMTZ6bS0xLjIxMiAxLjAzMmMwLS44NzYuNjQ5LTEuNTcgMS41MzYtMS41Ny44NjQgMCAxLjQ5OS42OTQgMS40OTkgMS41NTcgMCAuODc2LS42MzUgMS41ODMtMS41MTEgMS41ODMtLjg3NSAwLTEuNTI0LS43MDctMS41MjQtMS41N20zLjUzOCAwYzAtMS4xMTYtLjg3NS0xLjk5LTIuMDE0LTEuOTktMS4xMjcgMC0yLjAyNy44NzQtMi4wMjcgMS45OSAwIDEuMDkxLjkgMS45NjcgMi4wMjcgMS45NjcgMS4xMzkgMCAyLjAxNC0uODc2IDIuMDE0LTEuOTY3IiBmaWxsPSIjZmZmZmZmIi8+PC9nPjwvc3ZnPgo="/>
+      <image width="13" height="13" x="3.9" y="3.5" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTg5IiB3aWR0aD0iMjIxLjY2NyI+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBkPSJNMCAxNDEuNzVoMTY2LjI1VjBIMHoiLz48L2NsaXBQYXRoPjxjbGlwUGF0aCBpZD0iYiI+PHBhdGggZD0iTTAgMTQxLjc1aDE2Ni4yNVYwSDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzIDAgMCAtMS4zMzMzMyAwIDE4OSkiPjxwYXRoIGQ9Ik05NC4yNjggNzYuMjA0aDE1Ljc0M3YxNC4zMTJIOTQuMjY4em0tMTguNjA1IDBoMTUuNzQydjE0LjMxMkg3NS42NjN6bS0xOC42MDUgMGgxNS43NDN2MTQuMzEySDU3LjA1OHptLTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTJIMzguNDUzem0tMTguNjA1IDBoMTUuNzQzdjE0LjMxMkgxOS44NDh6bTE4LjYwNSAxNy4xNzNoMTUuNzQzdjE0LjMxMUgzOC40NTN6bTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTFINTcuMDU4em0xOC42MDUgMGgxNS43NDJ2MTQuMzExSDc1LjY2M3ptMCAxNy4xNzRoMTUuNzQydjE0LjMxMkg3NS42NjN6bTgxLjY1OC0yNi4wMDNjLTMuNDM4IDIuMy0xMS4zMzggMy4xNDMtMTcuNDE3IDEuOTk3LS43ODMgNS43MjYtMy45NzQgMTAuNjkxLTkuNzc5IDE1LjE3OWwtMy4zMzcgMi4yMjUtMi4yMjctMy4zNGMtMi44NTEtNC4yOTktNC4yNzUtMTAuMjU2LTMuODA4LTE1Ljk2Ny4yMS0yLjAxLjg3LTUuNjAzIDIuOTM3LTguNzY0LTIuMDY2LTEuMTEtNi4xNS0yLjY0LTExLjUzMy0yLjUzN0g4LjYyMmwtLjIwMy0xLjE5MmMtLjk3My01Ljc0LS45NTItMjMuNjUzIDEwLjY3OC0zNy40MiA4Ljg0LTEwLjQ2NCAyMi4wOTQtMTUuNzcyIDM5LjM5Mi0xNS43NzIgMzcuNSAwIDY1LjI0NCAxNy4yNjMgNzguMjM3IDQ4LjY0MSA1LjEwOS0uMTAyIDE2LjEwOS0uMDMgMjEuNzYgMTAuNzY2LjE0Ny4yNDguNDg2Ljg5NiAxLjQ3MyAyLjk0MmwuNTQxIDEuMTIyeiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9nPjxnIGNsaXAtcGF0aD0idXJsKCNiKSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4zMzMzMyAwIDAgLTEuMzMzMzMgMCAxODkpIj48cGF0aCBkPSJNMTA0LjEzNyAyNC4yNDFoLjIxNmMuMjUyIDAgLjQ1Ni4wODQuNDU2LjI4OCAwIC4xOC0uMTMyLjMtLjQyLjMtLjEyIDAtLjIwNC0uMDEyLS4yNTItLjAyNHptLS4wMTItMS4xMTVoLS40NTZ2MS45NjdjLjE4LjAzNi40MzIuMDYuNzU2LjA2LjM3MiAwIC41MzktLjA2LjY4NC0uMTQ0YS41NDcuNTQ3IDAgMCAwIC4xOS0uNDMyYzAtLjIxNi0uMTY3LS4zODQtLjQwNi0uNDU1di0uMDI1Yy4xOS0uMDcyLjMtLjIxNS4zNTktLjQ3OS4wNi0uMy4wOTYtLjQyLjE0NS0uNDkyaC0uNDkyYy0uMDYuMDcyLS4wOTYuMjUyLS4xNTcuNDgtLjAzNS4yMTYtLjE1NS4zMTItLjQwNy4zMTJoLS4yMTZ6bS0xLjIxMiAxLjAzMmMwLS44NzYuNjQ5LTEuNTcgMS41MzYtMS41Ny44NjQgMCAxLjQ5OS42OTQgMS40OTkgMS41NTcgMCAuODc2LS42MzUgMS41ODMtMS41MTEgMS41ODMtLjg3NSAwLTEuNTI0LS43MDctMS41MjQtMS41N20zLjUzOCAwYzAtMS4xMTYtLjg3NS0xLjk5LTIuMDE0LTEuOTktMS4xMjcgMC0yLjAyNy44NzQtMi4wMjcgMS45OSAwIDEuMDkxLjkgMS45NjcgMi4wMjcgMS45NjcgMS4xMzkgMCAyLjAxNC0uODc2IDIuMDE0LTEuOTY3IiBmaWxsPSIjZmZmZmZmIi8+PC9nPjwvc3ZnPgo="/>
     </svg>
   
 `
@@ -140,17 +136,15 @@ exports[`test/index.spec.js TAP generate badge with { status, icon } > snapshot 
 exports[`test/index.spec.js TAP generate badge with { subject, status, icon, style } > snapshot 1`] = `
 
       <svg width="96.69999999999999" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <g>
-          <rect width="64.3" height="20" fill="#555"/>
-          <rect x="64.3" width="32.4" height="20" fill="#08C"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-          <text x="22.5" y="14.8" textLength="37.1" fill="#000" opacity="0.1">docker</text>
+        <path fill="#555" d="M0 0h64.3v20H0z"/>
+        <path fill="#08C" d="M64.3 0h32.4v20H64.3z"/>
+        <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+          <text x="22.5" y="14.8" textLength="37.1" fill="#000" opacity=".1">docker</text>
           <text x="21.5" y="13.8" textLength="37.1">docker</text>
-          <text x="69.8" y="14.8" fill="#000" opacity="0.1" textLength="22.4">icon</text>
+          <text x="69.8" y="14.8" textLength="22.4" fill="#000" opacity=".1">icon</text>
           <text x="68.8" y="13.8" textLength="22.4">icon</text>
         </g>
-        <image x="3.8" y="3.4" width="13" height="13.2" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTg5IiB3aWR0aD0iMjIxLjY2NyI+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBkPSJNMCAxNDEuNzVoMTY2LjI1VjBIMHoiLz48L2NsaXBQYXRoPjxjbGlwUGF0aCBpZD0iYiI+PHBhdGggZD0iTTAgMTQxLjc1aDE2Ni4yNVYwSDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzIDAgMCAtMS4zMzMzMyAwIDE4OSkiPjxwYXRoIGQ9Ik05NC4yNjggNzYuMjA0aDE1Ljc0M3YxNC4zMTJIOTQuMjY4em0tMTguNjA1IDBoMTUuNzQydjE0LjMxMkg3NS42NjN6bS0xOC42MDUgMGgxNS43NDN2MTQuMzEySDU3LjA1OHptLTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTJIMzguNDUzem0tMTguNjA1IDBoMTUuNzQzdjE0LjMxMkgxOS44NDh6bTE4LjYwNSAxNy4xNzNoMTUuNzQzdjE0LjMxMUgzOC40NTN6bTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTFINTcuMDU4em0xOC42MDUgMGgxNS43NDJ2MTQuMzExSDc1LjY2M3ptMCAxNy4xNzRoMTUuNzQydjE0LjMxMkg3NS42NjN6bTgxLjY1OC0yNi4wMDNjLTMuNDM4IDIuMy0xMS4zMzggMy4xNDMtMTcuNDE3IDEuOTk3LS43ODMgNS43MjYtMy45NzQgMTAuNjkxLTkuNzc5IDE1LjE3OWwtMy4zMzcgMi4yMjUtMi4yMjctMy4zNGMtMi44NTEtNC4yOTktNC4yNzUtMTAuMjU2LTMuODA4LTE1Ljk2Ny4yMS0yLjAxLjg3LTUuNjAzIDIuOTM3LTguNzY0LTIuMDY2LTEuMTEtNi4xNS0yLjY0LTExLjUzMy0yLjUzN0g4LjYyMmwtLjIwMy0xLjE5MmMtLjk3My01Ljc0LS45NTItMjMuNjUzIDEwLjY3OC0zNy40MiA4Ljg0LTEwLjQ2NCAyMi4wOTQtMTUuNzcyIDM5LjM5Mi0xNS43NzIgMzcuNSAwIDY1LjI0NCAxNy4yNjMgNzguMjM3IDQ4LjY0MSA1LjEwOS0uMTAyIDE2LjEwOS0uMDMgMjEuNzYgMTAuNzY2LjE0Ny4yNDguNDg2Ljg5NiAxLjQ3MyAyLjk0MmwuNTQxIDEuMTIyeiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9nPjxnIGNsaXAtcGF0aD0idXJsKCNiKSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4zMzMzMyAwIDAgLTEuMzMzMzMgMCAxODkpIj48cGF0aCBkPSJNMTA0LjEzNyAyNC4yNDFoLjIxNmMuMjUyIDAgLjQ1Ni4wODQuNDU2LjI4OCAwIC4xOC0uMTMyLjMtLjQyLjMtLjEyIDAtLjIwNC0uMDEyLS4yNTItLjAyNHptLS4wMTItMS4xMTVoLS40NTZ2MS45NjdjLjE4LjAzNi40MzIuMDYuNzU2LjA2LjM3MiAwIC41MzktLjA2LjY4NC0uMTQ0YS41NDcuNTQ3IDAgMCAwIC4xOS0uNDMyYzAtLjIxNi0uMTY3LS4zODQtLjQwNi0uNDU1di0uMDI1Yy4xOS0uMDcyLjMtLjIxNS4zNTktLjQ3OS4wNi0uMy4wOTYtLjQyLjE0NS0uNDkyaC0uNDkyYy0uMDYuMDcyLS4wOTYuMjUyLS4xNTcuNDgtLjAzNS4yMTYtLjE1NS4zMTItLjQwNy4zMTJoLS4yMTZ6bS0xLjIxMiAxLjAzMmMwLS44NzYuNjQ5LTEuNTcgMS41MzYtMS41Ny44NjQgMCAxLjQ5OS42OTQgMS40OTkgMS41NTcgMCAuODc2LS42MzUgMS41ODMtMS41MTEgMS41ODMtLjg3NSAwLTEuNTI0LS43MDctMS41MjQtMS41N20zLjUzOCAwYzAtMS4xMTYtLjg3NS0xLjk5LTIuMDE0LTEuOTktMS4xMjcgMC0yLjAyNy44NzQtMi4wMjcgMS45OSAwIDEuMDkxLjkgMS45NjcgMi4wMjcgMS45NjcgMS4xMzkgMCAyLjAxNC0uODc2IDIuMDE0LTEuOTY3IiBmaWxsPSIjZmZmZmZmIi8+PC9nPjwvc3ZnPgo="/>
+        <image width="13" height="13.2" x="3.8" y="3.4" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMTg5IiB3aWR0aD0iMjIxLjY2NyI+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBkPSJNMCAxNDEuNzVoMTY2LjI1VjBIMHoiLz48L2NsaXBQYXRoPjxjbGlwUGF0aCBpZD0iYiI+PHBhdGggZD0iTTAgMTQxLjc1aDE2Ni4yNVYwSDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzIDAgMCAtMS4zMzMzMyAwIDE4OSkiPjxwYXRoIGQ9Ik05NC4yNjggNzYuMjA0aDE1Ljc0M3YxNC4zMTJIOTQuMjY4em0tMTguNjA1IDBoMTUuNzQydjE0LjMxMkg3NS42NjN6bS0xOC42MDUgMGgxNS43NDN2MTQuMzEySDU3LjA1OHptLTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTJIMzguNDUzem0tMTguNjA1IDBoMTUuNzQzdjE0LjMxMkgxOS44NDh6bTE4LjYwNSAxNy4xNzNoMTUuNzQzdjE0LjMxMUgzOC40NTN6bTE4LjYwNSAwaDE1Ljc0M3YxNC4zMTFINTcuMDU4em0xOC42MDUgMGgxNS43NDJ2MTQuMzExSDc1LjY2M3ptMCAxNy4xNzRoMTUuNzQydjE0LjMxMkg3NS42NjN6bTgxLjY1OC0yNi4wMDNjLTMuNDM4IDIuMy0xMS4zMzggMy4xNDMtMTcuNDE3IDEuOTk3LS43ODMgNS43MjYtMy45NzQgMTAuNjkxLTkuNzc5IDE1LjE3OWwtMy4zMzcgMi4yMjUtMi4yMjctMy4zNGMtMi44NTEtNC4yOTktNC4yNzUtMTAuMjU2LTMuODA4LTE1Ljk2Ny4yMS0yLjAxLjg3LTUuNjAzIDIuOTM3LTguNzY0LTIuMDY2LTEuMTEtNi4xNS0yLjY0LTExLjUzMy0yLjUzN0g4LjYyMmwtLjIwMy0xLjE5MmMtLjk3My01Ljc0LS45NTItMjMuNjUzIDEwLjY3OC0zNy40MiA4Ljg0LTEwLjQ2NCAyMi4wOTQtMTUuNzcyIDM5LjM5Mi0xNS43NzIgMzcuNSAwIDY1LjI0NCAxNy4yNjMgNzguMjM3IDQ4LjY0MSA1LjEwOS0uMTAyIDE2LjEwOS0uMDMgMjEuNzYgMTAuNzY2LjE0Ny4yNDguNDg2Ljg5NiAxLjQ3MyAyLjk0MmwuNTQxIDEuMTIyeiIgZmlsbD0iI2ZmZmZmZiIgZmlsbC1ydWxlPSJldmVub2RkIi8+PC9nPjxnIGNsaXAtcGF0aD0idXJsKCNiKSIgdHJhbnNmb3JtPSJtYXRyaXgoMS4zMzMzMyAwIDAgLTEuMzMzMzMgMCAxODkpIj48cGF0aCBkPSJNMTA0LjEzNyAyNC4yNDFoLjIxNmMuMjUyIDAgLjQ1Ni4wODQuNDU2LjI4OCAwIC4xOC0uMTMyLjMtLjQyLjMtLjEyIDAtLjIwNC0uMDEyLS4yNTItLjAyNHptLS4wMTItMS4xMTVoLS40NTZ2MS45NjdjLjE4LjAzNi40MzIuMDYuNzU2LjA2LjM3MiAwIC41MzktLjA2LjY4NC0uMTQ0YS41NDcuNTQ3IDAgMCAwIC4xOS0uNDMyYzAtLjIxNi0uMTY3LS4zODQtLjQwNi0uNDU1di0uMDI1Yy4xOS0uMDcyLjMtLjIxNS4zNTktLjQ3OS4wNi0uMy4wOTYtLjQyLjE0NS0uNDkyaC0uNDkyYy0uMDYuMDcyLS4wOTYuMjUyLS4xNTcuNDgtLjAzNS4yMTYtLjE1NS4zMTItLjQwNy4zMTJoLS4yMTZ6bS0xLjIxMiAxLjAzMmMwLS44NzYuNjQ5LTEuNTcgMS41MzYtMS41Ny44NjQgMCAxLjQ5OS42OTQgMS40OTkgMS41NTcgMCAuODc2LS42MzUgMS41ODMtMS41MTEgMS41ODMtLjg3NSAwLTEuNTI0LS43MDctMS41MjQtMS41N20zLjUzOCAwYzAtMS4xMTYtLjg3NS0xLjk5LTIuMDE0LTEuOTktMS4xMjcgMC0yLjAyNy44NzQtMi4wMjcgMS45OSAwIDEuMDkxLjkgMS45NjcgMi4wMjcgMS45NjcgMS4xMzkgMCAyLjAxNC0uODc2IDIuMDE0LTEuOTY3IiBmaWxsPSIjZmZmZmZmIi8+PC9nPjwvc3ZnPgo="/>
       </svg>
     
 `

--- a/tap-snapshots/test-round.spec.js-TAP.test.js
+++ b/tap-snapshots/test-round.spec.js-TAP.test.js
@@ -1,0 +1,14 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/round.spec.js TAP rounds integer to zero decimal places > result is correct 1`] = `
+1
+`
+
+exports[`test/round.spec.js TAP rounds decimal to one decimal place > result is correct 1`] = `
+1.6
+`

--- a/test/calc-text-width.spec.js
+++ b/test/calc-text-width.spec.js
@@ -1,5 +1,5 @@
 const tap = require('tap')
-const calcWidth = require('../lib/calc-text-width.js').Verdana11
+const calcWidth = require('../lib/calc-text-width').Verdana11
 
 tap.test('basic functions', t => {
   t.ok(typeof calcWidth === 'function', 'export calcWidth function')

--- a/test/round.spec.js
+++ b/test/round.spec.js
@@ -1,0 +1,19 @@
+const tap = require('tap')
+const round = require('../lib/round')
+
+tap.test('basic functions', t => {
+  t.ok(typeof round === 'function', 'export round function')
+  t.ok(Number.isFinite(round('')), 'result is a number')
+  t.ok(round('') === 0, 'return 0 for empty string')
+  t.end()
+})
+
+tap.test('rounds integer to zero decimal places', t => {
+  t.matchSnapshot(round(1), 'result is correct')
+  t.end()
+})
+
+tap.test('rounds decimal to one decimal place', t => {
+  t.matchSnapshot(round(1.599999999999994), 'result is correct')
+  t.end()
+})


### PR DESCRIPTION
#### Changes

- Extends rounding to the rectangle widths instead of just the text width.
- Removes `xmlns:xlink` from the SVG when no icon is present
- Reordered some properties to be consistent
- Converted `rect` to `path`, removing the need for 2 groups in flat badges
   ```diff
   -<g><rect width="35.1" height="20" fill="#555"/><rect x="35.1" width="45.5" height="20" fill="#0BC"/></g>
   +<path fill="#555" d="M0 0h35.1v20H0z"/><path fill="#08C" d="M35.1 0h45.5v20H35.1z"/>
   ```

Based on the first snapshot, with this change unnecessary whitespace has gone from 14% to 20% of the badge size (~150 bytes) and the badge size reduced by 140 bytes.

Further reductions can be made in [badgen-service](https://github.com/amio/badgen-service) with gzip/brotli support:
- gzip reduces the size by 54% (~500 bytes). #3 (but at prepublish, not runtime) would only save an extra 20 bytes on the output.
- brotli reduces the badge size by 61% (~570 bytes) with #3 saving the same amount.

#### Benchmarks

##### PR

```
[classic] style, long params x 797,333 ops/sec ±1.87% (89 runs sampled)
[classic] style, full params x 885,457 ops/sec ±1.48% (88 runs sampled)
   [flat] style, long params x 528,192 ops/sec ±1.13% (91 runs sampled)
   [flat] style, full params x 464,142 ops/sec ±4.81% (74 runs sampled)
[classic] style, with emoji  x 491,251 ops/sec ±1.43% (88 runs sampled)
[classic] style, with icon   x 718,199 ops/sec ±1.20% (89 runs sampled)
   [flat] style, with emoji  x 330,065 ops/sec ±1.11% (91 runs sampled)
   [flat] style, with icon   x 431,363 ops/sec ±0.85% (90 runs sampled)
```

##### Master

```
[classic] style, long params x 654,538 ops/sec ±2.61% (78 runs sampled)
[classic] style, full params x 766,651 ops/sec ±1.55% (85 runs sampled)
   [flat] style, long params x 449,018 ops/sec ±2.14% (82 runs sampled)
   [flat] style, full params x 470,980 ops/sec ±1.78% (83 runs sampled)
[classic] style, with emoji  x 466,423 ops/sec ±2.08% (83 runs sampled)
[classic] style, with icon   x 647,043 ops/sec ±1.63% (82 runs sampled)
```