### PR TITLE
Fix accented character width

### DIFF
--- a/lib/calc-text-width.js
+++ b/lib/calc-text-width.js
@@ -11,13 +11,13 @@ const calcWidth = (charWidthTable) => {
     if (astral) text = [...text]
 
     let total = 0
-    let width = 0
     let i = text.length
     let char = ''
     while (i--) {
       char = text[i]
-      width = widthTable[char.charCodeAt()]
-      total += width === undefined ? (widthTable[char.normalize('NFD').charCodeAt()] || fallbackWidth) : width
+      total += widthTable[char.charCodeAt()] ||
+        widthTable[char.normalize('NFD').charCodeAt()] ||
+        fallbackWidth
     }
     return total
   }

--- a/lib/calc-text-width.js
+++ b/lib/calc-text-width.js
@@ -5,16 +5,19 @@ const SCALE = 10 // Prevent results like 60.599999999999994
 const calcWidth = (charWidthTable) => {
   const widthTable = charWidthTable.map(w => Math.round(w * SCALE))
   widthTable[64] = widthTable[64] + 6 // Slightly increase width of "@" by 0.6px
+  const fallbackWidth = widthTable[64] // Width as "@" for overflows
 
   return (text, astral) => {
     if (astral) text = [...text]
 
     let total = 0
-    let code = 0
+    let width = 0
     let i = text.length
+    let char = ''
     while (i--) {
-      code = text[i].charCodeAt()
-      total += widthTable[code < 127 ? code : 64] // Width as "@" for overflows
+      char = text[i]
+      width = widthTable[char.charCodeAt()]
+      total += width === undefined ? (widthTable[char.normalize('NFD').charCodeAt()] || fallbackWidth) : width
     }
     return total
   }

--- a/test/calc-text-width.spec.js
+++ b/test/calc-text-width.spec.js
@@ -18,6 +18,11 @@ tap.test('calc width for unicode', t => {
   t.end()
 })
 
+tap.test('calc width for accented characters', t => {
+  t.ok(calcWidth('ien') === calcWidth('ïéǹ'), 'normal and accented characters have the same width')
+  t.end()
+})
+
 tap.test('calc width for emojis', t => {
   t.matchSnapshot(calcWidth('💩🤱🦄', true), 'result is correct')
   t.end()

--- a/test/calc-text-width.spec.js
+++ b/test/calc-text-width.spec.js
@@ -19,7 +19,9 @@ tap.test('calc width for unicode', t => {
 })
 
 tap.test('calc width for accented characters', t => {
-  t.ok(calcWidth('ien') === calcWidth('ïéǹ'), 'normal and accented characters have the same width')
+  t.ok(calcWidth('i') === calcWidth('ï'), 'i and ï have the same width')
+  t.ok(calcWidth('e') === calcWidth('é'), 'e and é have the same width')
+  t.ok(calcWidth('s') === calcWidth('ṣ'), 's and ṣ have the same width')
   t.end()
 })
 


### PR DESCRIPTION
Accented characters charcode was outside basic ASCII table and treated as emoji (using '@' width). This looks really weird on non-english languages:
![](https://badgen.net/badge/french/d%C3%A9j%C3%A0%20vu)
![](https://badgen.net/badge/spanish/cu%C3%A1l)

If width is not found, normalize the string and try again. This method hit the performances pretty badly by cutting in half ops/sec for emoji benchmarks.
No impact on ascii chars however.

Sorry for the spam :upside_down_face: 