### PR TITLE
Edit SVG indentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,44 +16,40 @@ module.exports = ({ subject, status, color, style, icon, iconWidth = 13 }) => {
   const xlink = icon ? ' xmlns:xlink="http://www.w3.org/1999/xlink"' : ''
 
   if (style === 'flat') {
-    return `
-      <svg width="${width / 10}" height="20" viewBox="0 0 ${width} 200" xmlns="http://www.w3.org/2000/svg"${xlink}>
-        <g>
-          <rect fill="#555" width="${sbRectWidth}" height="200"/>
-          <rect fill="#${color}" x="${sbRectWidth}" width="${stRectWidth}" height="200"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-          <text x="${icon ? '220' : '50'}" y="148" textLength="${sbTextWidth}" fill="#000" opacity="0.1">${subject}</text>
-          <text x="${icon ? '210' : '50'}" y="138" textLength="${sbTextWidth}">${subject}</text>
-          <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.1">${status}</text>
-          <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}">${status}</text>
-        </g>
-        ${icon ? `<image x="40" y="35" width="${iconWidth}" height="132" xlink:href="${icon}"/>` : ''}
-      </svg>
-    `
+    return `<svg width="${width / 10}" height="20" viewBox="0 0 ${width} 200" xmlns="http://www.w3.org/2000/svg"${xlink}>
+  <g>
+    <rect fill="#555" width="${sbRectWidth}" height="200"/>
+    <rect fill="#${color}" x="${sbRectWidth}" width="${stRectWidth}" height="200"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="${icon ? '220' : '50'}" y="148" textLength="${sbTextWidth}" fill="#000" opacity="0.1">${subject}</text>
+    <text x="${icon ? '210' : '50'}" y="138" textLength="${sbTextWidth}">${subject}</text>
+    <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.1">${status}</text>
+    <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}">${status}</text>
+  </g>
+  ${icon ? `<image x="40" y="35" width="${iconWidth}" height="132" xlink:href="${icon}"/>` : ''}
+</svg>`
   }
 
-  return `
-    <svg width="${width / 10}" height="20" viewBox="0 0 ${width} 200" xmlns="http://www.w3.org/2000/svg"${xlink}>
-      <linearGradient id="a" x2="0" y2="100%">
-        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
-        <stop offset="1" stop-opacity=".1"/>
-      </linearGradient>
-      <mask id="m"><rect width="${width}" height="200" rx="30" fill="#FFF"/></mask>
-      <g mask="url(#m)">
-        <rect width="${sbRectWidth}" height="200" fill="#555"/>
-        <rect width="${stRectWidth}" height="200" fill="#${color}" x="${sbRectWidth}"/>
-        <rect width="${width}" height="200" fill="url(#a)"/>
-      </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-        <text x="${icon ? '220' : '60'}" y="148" textLength="${sbTextWidth}" fill="#000" opacity="0.25">${subject}</text>
-        <text x="${icon ? '210' : '50'}" y="138" textLength="${sbTextWidth}">${subject}</text>
-        <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.25">${status}</text>
-        <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}">${status}</text>
-      </g>
-      ${icon ? `<image x="40" y="35" width="${iconWidth}" height="130" xlink:href="${icon}"/>` : ''}
-    </svg>
-  `
+  return `<svg width="${width / 10}" height="20" viewBox="0 0 ${width} 200" xmlns="http://www.w3.org/2000/svg"${xlink}>
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="${width}" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="${sbRectWidth}" height="200" fill="#555"/>
+    <rect width="${stRectWidth}" height="200" fill="#${color}" x="${sbRectWidth}"/>
+    <rect width="${width}" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="${icon ? '220' : '60'}" y="148" textLength="${sbTextWidth}" fill="#000" opacity="0.25">${subject}</text>
+    <text x="${icon ? '210' : '50'}" y="138" textLength="${sbTextWidth}">${subject}</text>
+    <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.25">${status}</text>
+    <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}">${status}</text>
+  </g>
+  ${icon ? `<image x="40" y="35" width="${iconWidth}" height="130" xlink:href="${icon}"/>` : ''}
+</svg>`
 }
 
 const typeAssert = (assertion, message) => {

--- a/tap-snapshots/test-index.spec.js-TAP.test.js
+++ b/tap-snapshots/test-index.spec.js-TAP.test.js
@@ -6,175 +6,159 @@
  */
 'use strict'
 exports[`test/index.spec.js TAP generate badge with { subject, status } > snapshot 1`] = `
-
-    <svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
-      <linearGradient id="a" x2="0" y2="100%">
-        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
-        <stop offset="1" stop-opacity=".1"/>
-      </linearGradient>
-      <mask id="m"><rect width="804" height="200" rx="30" fill="#FFF"/></mask>
-      <g mask="url(#m)">
-        <rect width="349" height="200" fill="#555"/>
-        <rect width="455" height="200" fill="#08C" x="349"/>
-        <rect width="804" height="200" fill="url(#a)"/>
-      </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-        <text x="60" y="148" textLength="249" fill="#000" opacity="0.25">npm</text>
-        <text x="50" y="138" textLength="249">npm</text>
-        <text x="404" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
-        <text x="394" y="138" textLength="355">v1.0.0</text>
-      </g>
-      
-    </svg>
+<svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="804" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="349" height="200" fill="#555"/>
+    <rect width="455" height="200" fill="#08C" x="349"/>
+    <rect width="804" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="60" y="148" textLength="249" fill="#000" opacity="0.25">npm</text>
+    <text x="50" y="138" textLength="249">npm</text>
+    <text x="404" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
+    <text x="394" y="138" textLength="355">v1.0.0</text>
+  </g>
   
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, color } > snapshot 1`] = `
-
-    <svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
-      <linearGradient id="a" x2="0" y2="100%">
-        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
-        <stop offset="1" stop-opacity=".1"/>
-      </linearGradient>
-      <mask id="m"><rect width="804" height="200" rx="30" fill="#FFF"/></mask>
-      <g mask="url(#m)">
-        <rect width="349" height="200" fill="#555"/>
-        <rect width="455" height="200" fill="#ADF" x="349"/>
-        <rect width="804" height="200" fill="url(#a)"/>
-      </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-        <text x="60" y="148" textLength="249" fill="#000" opacity="0.25">npm</text>
-        <text x="50" y="138" textLength="249">npm</text>
-        <text x="404" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
-        <text x="394" y="138" textLength="355">v1.0.0</text>
-      </g>
-      
-    </svg>
+<svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="804" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="349" height="200" fill="#555"/>
+    <rect width="455" height="200" fill="#ADF" x="349"/>
+    <rect width="804" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="60" y="148" textLength="249" fill="#000" opacity="0.25">npm</text>
+    <text x="50" y="138" textLength="249">npm</text>
+    <text x="404" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
+    <text x="394" y="138" textLength="355">v1.0.0</text>
+  </g>
   
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, style } > snapshot 1`] = `
-
-      <svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
-        <g>
-          <rect fill="#555" width="349" height="200"/>
-          <rect fill="#08C" x="349" width="455" height="200"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-          <text x="50" y="148" textLength="249" fill="#000" opacity="0.1">npm</text>
-          <text x="50" y="138" textLength="249">npm</text>
-          <text x="404" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
-          <text x="394" y="138" textLength="355">v1.0.0</text>
-        </g>
-        
-      </svg>
-    
+<svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <rect fill="#555" width="349" height="200"/>
+    <rect fill="#08C" x="349" width="455" height="200"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="50" y="148" textLength="249" fill="#000" opacity="0.1">npm</text>
+    <text x="50" y="138" textLength="249">npm</text>
+    <text x="404" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
+    <text x="394" y="138" textLength="355">v1.0.0</text>
+  </g>
+  
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, color, style } > snapshot 1`] = `
-
-      <svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
-        <g>
-          <rect fill="#555" width="349" height="200"/>
-          <rect fill="#ADF" x="349" width="455" height="200"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-          <text x="50" y="148" textLength="249" fill="#000" opacity="0.1">npm</text>
-          <text x="50" y="138" textLength="249">npm</text>
-          <text x="404" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
-          <text x="394" y="138" textLength="355">v1.0.0</text>
-        </g>
-        
-      </svg>
-    
+<svg width="80.4" height="20" viewBox="0 0 804 200" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <rect fill="#555" width="349" height="200"/>
+    <rect fill="#ADF" x="349" width="455" height="200"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="50" y="148" textLength="249" fill="#000" opacity="0.1">npm</text>
+    <text x="50" y="138" textLength="249">npm</text>
+    <text x="404" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
+    <text x="394" y="138" textLength="355">v1.0.0</text>
+  </g>
+  
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, icon } > snapshot 1`] = `
-
-    <svg width="95.5" height="20" viewBox="0 0 955 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <linearGradient id="a" x2="0" y2="100%">
-        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
-        <stop offset="1" stop-opacity=".1"/>
-      </linearGradient>
-      <mask id="m"><rect width="955" height="200" rx="30" fill="#FFF"/></mask>
-      <g mask="url(#m)">
-        <rect width="631" height="200" fill="#555"/>
-        <rect width="324" height="200" fill="#08C" x="631"/>
-        <rect width="955" height="200" fill="url(#a)"/>
-      </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-        <text x="220" y="148" textLength="371" fill="#000" opacity="0.25">docker</text>
-        <text x="210" y="138" textLength="371">docker</text>
-        <text x="686" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
-        <text x="676" y="138" textLength="224">icon</text>
-      </g>
-      <image x="40" y="35" width="130" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
-    </svg>
-  
+<svg width="95.5" height="20" viewBox="0 0 955 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="955" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="631" height="200" fill="#555"/>
+    <rect width="324" height="200" fill="#08C" x="631"/>
+    <rect width="955" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="220" y="148" textLength="371" fill="#000" opacity="0.25">docker</text>
+    <text x="210" y="138" textLength="371">docker</text>
+    <text x="686" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
+    <text x="676" y="138" textLength="224">icon</text>
+  </g>
+  <image x="40" y="35" width="130" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { status, icon } > snapshot 1`] = `
-
-    <svg width="53.6" height="20" viewBox="0 0 536 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <linearGradient id="a" x2="0" y2="100%">
-        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
-        <stop offset="1" stop-opacity=".1"/>
-      </linearGradient>
-      <mask id="m"><rect width="536" height="200" rx="30" fill="#FFF"/></mask>
-      <g mask="url(#m)">
-        <rect width="212" height="200" fill="#555"/>
-        <rect width="324" height="200" fill="#08C" x="212"/>
-        <rect width="536" height="200" fill="url(#a)"/>
-      </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-        <text x="220" y="148" textLength="0" fill="#000" opacity="0.25"></text>
-        <text x="210" y="138" textLength="0"></text>
-        <text x="267" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
-        <text x="257" y="138" textLength="224">icon</text>
-      </g>
-      <image x="40" y="35" width="130" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
-    </svg>
-  
+<svg width="53.6" height="20" viewBox="0 0 536 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="536" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="212" height="200" fill="#555"/>
+    <rect width="324" height="200" fill="#08C" x="212"/>
+    <rect width="536" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="220" y="148" textLength="0" fill="#000" opacity="0.25"></text>
+    <text x="210" y="138" textLength="0"></text>
+    <text x="267" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
+    <text x="257" y="138" textLength="224">icon</text>
+  </g>
+  <image x="40" y="35" width="130" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { status, icon, iconWidth } > snapshot 1`] = `
-
-    <svg width="55.6" height="20" viewBox="0 0 556 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <linearGradient id="a" x2="0" y2="100%">
-        <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
-        <stop offset="1" stop-opacity=".1"/>
-      </linearGradient>
-      <mask id="m"><rect width="556" height="200" rx="30" fill="#FFF"/></mask>
-      <g mask="url(#m)">
-        <rect width="232" height="200" fill="#555"/>
-        <rect width="324" height="200" fill="#08C" x="232"/>
-        <rect width="556" height="200" fill="url(#a)"/>
-      </g>
-      <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-        <text x="220" y="148" textLength="0" fill="#000" opacity="0.25"></text>
-        <text x="210" y="138" textLength="0"></text>
-        <text x="287" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
-        <text x="277" y="138" textLength="224">icon</text>
-      </g>
-      <image x="40" y="35" width="150" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
-    </svg>
-  
+<svg width="55.6" height="20" viewBox="0 0 556 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="556" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="232" height="200" fill="#555"/>
+    <rect width="324" height="200" fill="#08C" x="232"/>
+    <rect width="556" height="200" fill="url(#a)"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="220" y="148" textLength="0" fill="#000" opacity="0.25"></text>
+    <text x="210" y="138" textLength="0"></text>
+    <text x="287" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
+    <text x="277" y="138" textLength="224">icon</text>
+  </g>
+  <image x="40" y="35" width="150" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
+</svg>
 `
 
 exports[`test/index.spec.js TAP generate badge with { subject, status, icon, style } > snapshot 1`] = `
-
-      <svg width="95.5" height="20" viewBox="0 0 955 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <g>
-          <rect fill="#555" width="631" height="200"/>
-          <rect fill="#08C" x="631" width="324" height="200"/>
-        </g>
-        <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-          <text x="220" y="148" textLength="371" fill="#000" opacity="0.1">docker</text>
-          <text x="210" y="138" textLength="371">docker</text>
-          <text x="686" y="148" textLength="224" fill="#000" opacity="0.1">icon</text>
-          <text x="676" y="138" textLength="224">icon</text>
-        </g>
-        <image x="40" y="35" width="130" height="132" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
-      </svg>
-    
+<svg width="95.5" height="20" viewBox="0 0 955 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g>
+    <rect fill="#555" width="631" height="200"/>
+    <rect fill="#08C" x="631" width="324" height="200"/>
+  </g>
+  <g fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="220" y="148" textLength="371" fill="#000" opacity="0.1">docker</text>
+    <text x="210" y="138" textLength="371">docker</text>
+    <text x="686" y="148" textLength="224" fill="#000" opacity="0.1">icon</text>
+    <text x="676" y="138" textLength="224">icon</text>
+  </g>
+  <image x="40" y="35" width="130" height="132" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
+</svg>
 `


### PR DESCRIPTION
So I noticed something I couldn't understand: 
- The flat badge was indented with 6 spaces at the root element
- The classic badge was indented with 4 spaces at the root element

So I changed things in the indentation:
- Removed indentation so the root element starts at col:0
- Removed first empty line
- Removed last empty line

It kinda looks weird in the code, but the rendered badge looks much better.

It also saves: 
- 80 useless characters in the flat badge (around 12% of a simple badge (like in screenshot below))
- 78 useless characters in the classic badge (around 8% of a simple badge)

Diff preview

![image](https://user-images.githubusercontent.com/17952318/44643279-373f7f00-a9d0-11e8-851f-93ecef6a8b62.png)
