### PR TITLE
feat: choose the text color based on the background to ensure contrast

### DIFF
--- a/preview/preview.md
+++ b/preview/preview.md
@@ -22,7 +22,8 @@
 |![](/style/standard/f2a) | [/style/standard/f2a](/style/standard/f2a) |
 |![](/license/Apache-2.0/blue) | [/license/Apache-2.0/blue](/license/Apache-2.0/blue) |
 |![](/Language/Swift%203.0.1/orange) | [/Language/Swift%203.0.1/orange](/Language/Swift%203.0.1/orange) |
-|![](/labelColor/badge/yellow?icon=chrome&labelColor=red)
+|![](/labelColor/badge/yellow?icon=chrome&labelColor=red) | [/labelColor/badge/yellow?icon=chrome&labelColor=red](/labelColor/badge/yellow?icon=chrome&labelColor=red) |
+|![](/VS%20Code%20Marketplace/Vue.volar?color=eee) | [/VS%20Code%20Marketplace/Vue.volar?color=eee](/VS%20Code%20Marketplace/Vue.volar?color=eee) |
 
 ## Flat Style
 
@@ -33,6 +34,8 @@
 |![](/style/standard/f2a?style=flat) | [/style/standard/f2a?style=flat](/style/standard/f2a?style=flat) |
 |![](/license/Apache-2.0/blue?style=flat) | [/license/Apache-2.0/blue?style=flat](/license/Apache-2.0/blue?style=flat) |
 |![](/Language/Swift%203.0.1/orange?style=flat) | [/Language/Swift%203.0.1/orange?style=flat](/Language/Swift%203.0.1/orange?style=flat) |
+|![](/labelColor/badge/yellow?style=flat&icon=chrome&labelColor=red) | [/labelColor/badge/yellow?style=flat&icon=chrome&labelColor=red](/labelColor/badge/yellow?style=flat&icon=chrome&labelColor=red) |
+|![](/VS%20Code%20Marketplace/Vue.volar?style=flat&color=eee) | [/VS%20Code%20Marketplace/Vue.volar?style=flat&color=eee](/VS%20Code%20Marketplace/Vue.volar?style=flat&color=eee) |
 
 ## Astral Plain Charset (emoji)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,37 @@ export interface BadgenOptions {
   subject?: string;
   color?: ColorPreset;
   label?: string;
-  labelColor?: string
+  labelColor?: string;
   style?: StyleOption;
   icon?: string;
   iconWidth?: number;
-  scale?: number
+  scale?: number;
+}
+
+/**
+ * Based on Shields.io (brightness() function)
+ */
+function colorBrightness (hex: string): number {
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+  }
+
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+
+  return (r * 299 + g * 587 + b * 114) / 255000
+}
+
+/**
+ * Based on Shields.io (colorsForBackground() function)
+ */
+function colorsForBackground (hex: string): { textColor: string; shadowColor: string } {
+  if (colorBrightness(hex) <= 0.69) {
+    return { textColor: '#fff', shadowColor: '#000' }
+  } else {
+    return { textColor: '#000', shadowColor: '#fff' }
+  }
 }
 
 export function badgen ({
@@ -38,6 +64,9 @@ export function badgen ({
   color = colorPresets[color] || color
   labelColor = colorPresets[labelColor] || labelColor
   iconWidth = iconWidth * 10
+
+  const { textColor: labelTextColor, shadowColor: labelShadowColor } = colorsForBackground(labelColor)
+  const { textColor: statusTextColor, shadowColor: statusShadowColor } = colorsForBackground(color)
 
   const iconSpanWidth = icon ? (label?.length ? iconWidth + 30 : iconWidth - 18) : 0
   const sbTextStart = icon ? (iconSpanWidth + 50) : 50
@@ -65,11 +94,11 @@ export function badgen ({
     <rect fill="#${labelColor}" width="${sbRectWidth}" height="200"/>
     <rect fill="#${color}" x="${sbRectWidth}" width="${stRectWidth}" height="200"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="${sbTextStart + 10}" y="148" textLength="${sbTextWidth}" fill="#000" opacity="0.1">${label}</text>
-    <text x="${sbTextStart}" y="138" textLength="${sbTextWidth}">${label}</text>
-    <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.1">${status}</text>
-    <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}">${status}</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="${sbTextStart + 10}" y="148" textLength="${sbTextWidth}" fill="${labelShadowColor}" opacity="0.1">${label}</text>
+    <text x="${sbTextStart}" y="138" textLength="${sbTextWidth}" fill="${labelTextColor}">${label}</text>
+    <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="${statusShadowColor}" opacity="0.1">${status}</text>
+    <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}" fill="${statusTextColor}">${status}</text>
   </g>
   ${icon ? `<image x="40" y="35" width="${iconWidth}" height="132" xlink:href="${icon}"/>` : ''}
 </svg>`
@@ -87,11 +116,11 @@ export function badgen ({
     <rect width="${stRectWidth}" height="200" fill="#${color}" x="${sbRectWidth}"/>
     <rect width="${width}" height="200" fill="url(#${gradientId})"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="${sbTextStart + 10}" y="148" textLength="${sbTextWidth}" fill="#000" opacity="0.25">${label}</text>
-    <text x="${sbTextStart}" y="138" textLength="${sbTextWidth}">${label}</text>
-    <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.25">${status}</text>
-    <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}">${status}</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="${sbTextStart + 10}" y="148" textLength="${sbTextWidth}" fill="${labelShadowColor}" opacity="0.25">${label}</text>
+    <text x="${sbTextStart}" y="138" textLength="${sbTextWidth}" fill="${labelTextColor}">${label}</text>
+    <text x="${sbRectWidth + 55}" y="148" textLength="${stTextWidth}" fill="${statusShadowColor}" opacity="0.25">${status}</text>
+    <text x="${sbRectWidth + 45}" y="138" textLength="${stTextWidth}" fill="${statusTextColor}">${status}</text>
   </g>
   ${icon ? `<image x="40" y="35" width="${iconWidth}" height="130" xlink:href="${icon}"/>` : ''}
 </svg>`
@@ -100,6 +129,8 @@ export function badgen ({
 function bare ({ status, color = 'blue', style, scale = 1 }: BadgenOptions) {
   typeAssert(typeof status === 'string', '<status> must be string')
   color = colorPresets[color] || color || colorPresets.blue
+
+  const { textColor: statusTextColor, shadowColor: statusShadowColor } = colorsForBackground(color)
 
   const stTextWidth = calcWidth(status)
   const stRectWidth = stTextWidth + 115
@@ -116,9 +147,9 @@ function bare ({ status, color = 'blue', style, scale = 1 }: BadgenOptions) {
   <g>
     <rect fill="#${color}" x="0" width="${stRectWidth}" height="200"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="65" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.1">${status}</text>
-    <text x="55" y="138" textLength="${stTextWidth}">${status}</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="65" y="148" textLength="${stTextWidth}" fill="${statusShadowColor}" opacity="0.1">${status}</text>
+    <text x="55" y="138" textLength="${stTextWidth}" fill="${statusTextColor}">${status}</text>
   </g>
 </svg>`
   }
@@ -134,9 +165,9 @@ function bare ({ status, color = 'blue', style, scale = 1 }: BadgenOptions) {
     <rect width="${stRectWidth}" height="200" fill="#${color}" x="0"/>
     <rect width="${stRectWidth}" height="200" fill="url(#${gradientId})"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="65" y="148" textLength="${stTextWidth}" fill="#000" opacity="0.25">${status}</text>
-    <text x="55" y="138" textLength="${stTextWidth}">${status}</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="65" y="148" textLength="${stTextWidth}" fill="${statusShadowColor}" opacity="0.25">${status}</text>
+    <text x="55" y="138" textLength="${stTextWidth}" fill="${statusTextColor}">${status}</text>
   </g>
 </svg>`
 }

--- a/tap-snapshots/test/badgen.spec.js.test.cjs
+++ b/tap-snapshots/test/badgen.spec.js.test.cjs
@@ -18,11 +18,11 @@ exports[`test/badgen.spec.js TAP ensure badgen() correctly escapes string inputs
     <rect width="876" height="200" fill="#&lt;escape me&gt;" x="1036"/>
     <rect width="1912" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="220" y="148" textLength="776" fill="#000" opacity="0.25">&lt;escape me&gt;</text>
-    <text x="210" y="138" textLength="776">&lt;escape me&gt;</text>
-    <text x="1091" y="148" textLength="776" fill="#000" opacity="0.25">&lt;escape me&gt;</text>
-    <text x="1081" y="138" textLength="776">&lt;escape me&gt;</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="220" y="148" textLength="776" fill="#fff" opacity="0.25">&lt;escape me&gt;</text>
+    <text x="210" y="138" textLength="776" fill="#000">&lt;escape me&gt;</text>
+    <text x="1091" y="148" textLength="776" fill="#fff" opacity="0.25">&lt;escape me&gt;</text>
+    <text x="1081" y="138" textLength="776" fill="#000">&lt;escape me&gt;</text>
   </g>
   <image x="40" y="35" width="130" height="130" xlink:href="&lt;escape me&gt;"/>
 </svg>
@@ -40,9 +40,9 @@ exports[`test/badgen.spec.js TAP ensure bare() correctly escapes string inputs >
     <rect width="891" height="200" fill="#&lt;escape me&gt;" x="0"/>
     <rect width="891" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="65" y="148" textLength="776" fill="#000" opacity="0.25">&lt;escape me&gt;</text>
-    <text x="55" y="138" textLength="776">&lt;escape me&gt;</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="65" y="148" textLength="776" fill="#fff" opacity="0.25">&lt;escape me&gt;</text>
+    <text x="55" y="138" textLength="776" fill="#000">&lt;escape me&gt;</text>
   </g>
 </svg>
 `
@@ -60,11 +60,11 @@ exports[`test/badgen.spec.js TAP generate badge with { label, status } > snapsho
     <rect width="455" height="200" fill="#08C" x="349"/>
     <rect width="804" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="249" fill="#000" opacity="0.25">npm</text>
-    <text x="50" y="138" textLength="249">npm</text>
+    <text x="50" y="138" textLength="249" fill="#fff">npm</text>
     <text x="404" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
-    <text x="394" y="138" textLength="355">v1.0.0</text>
+    <text x="394" y="138" textLength="355" fill="#fff">v1.0.0</text>
   </g>
   
 </svg>
@@ -83,11 +83,11 @@ exports[`test/badgen.spec.js TAP generate badge with { label, status, color } > 
     <rect width="455" height="200" fill="#ADF" x="349"/>
     <rect width="804" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="249" fill="#000" opacity="0.25">npm</text>
-    <text x="50" y="138" textLength="249">npm</text>
-    <text x="404" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
-    <text x="394" y="138" textLength="355">v1.0.0</text>
+    <text x="50" y="138" textLength="249" fill="#fff">npm</text>
+    <text x="404" y="148" textLength="355" fill="#fff" opacity="0.25">v1.0.0</text>
+    <text x="394" y="138" textLength="355" fill="#000">v1.0.0</text>
   </g>
   
 </svg>
@@ -100,11 +100,11 @@ exports[`test/badgen.spec.js TAP generate badge with { label, status, color, sty
     <rect fill="#555" width="349" height="200"/>
     <rect fill="#ADF" x="349" width="455" height="200"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="249" fill="#000" opacity="0.1">npm</text>
-    <text x="50" y="138" textLength="249">npm</text>
-    <text x="404" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
-    <text x="394" y="138" textLength="355">v1.0.0</text>
+    <text x="50" y="138" textLength="249" fill="#fff">npm</text>
+    <text x="404" y="148" textLength="355" fill="#fff" opacity="0.1">v1.0.0</text>
+    <text x="394" y="138" textLength="355" fill="#000">v1.0.0</text>
   </g>
   
 </svg>
@@ -123,11 +123,11 @@ exports[`test/badgen.spec.js TAP generate badge with { label, status, icon } > s
     <rect width="324" height="200" fill="#08C" x="631"/>
     <rect width="955" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="220" y="148" textLength="371" fill="#000" opacity="0.25">docker</text>
-    <text x="210" y="138" textLength="371">docker</text>
+    <text x="210" y="138" textLength="371" fill="#fff">docker</text>
     <text x="686" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
-    <text x="676" y="138" textLength="224">icon</text>
+    <text x="676" y="138" textLength="224" fill="#fff">icon</text>
   </g>
   <image x="40" y="35" width="130" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
 </svg>
@@ -140,11 +140,11 @@ exports[`test/badgen.spec.js TAP generate badge with { label, status, icon, styl
     <rect fill="#555" width="631" height="200"/>
     <rect fill="#08C" x="631" width="324" height="200"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="220" y="148" textLength="371" fill="#000" opacity="0.1">docker</text>
-    <text x="210" y="138" textLength="371">docker</text>
+    <text x="210" y="138" textLength="371" fill="#fff">docker</text>
     <text x="686" y="148" textLength="224" fill="#000" opacity="0.1">icon</text>
-    <text x="676" y="138" textLength="224">icon</text>
+    <text x="676" y="138" textLength="224" fill="#fff">icon</text>
   </g>
   <image x="40" y="35" width="130" height="132" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNDAuOTI1IiBoZWlnaHQ9IjIwMi42NzYiIHZpZXdCb3g9IjAgMCA5MC4yMDMgNTMuNjI1Ij48ZyBmaWxsPSIjZmZmIj48cGF0aCBvcGFjaXR5PSIuNDU2IiBkPSJNNDUuMjE2IDMuODI2Yy0xMi44MzYgMC0yMi4yOCAzLjYzNC0yNi44ODQgMTAuNTMxLS4wOTEtLjEwNi0uMTcxLS4xNzItLjI2Ni0uMzAyLS40NTktLjYyOS0uOTQ1LTEuNDg2LTEuNDI4LTIuMzg0LS40ODQtLjg5OC0uOTY3LTEuODM1LTEuNDg1LTIuNjctLjUxOC0uODM1LTEuMDI1LTEuNTkzLTEuODc0LTIuMTE2LS45MjctLjU3My0xLjczMy0uODI4LTIuMzQ3LS45MTZhMy42ODMgMy42ODMgMCAwIDAtLjg2Mi0uMDE1Yy0xLjUzNS4wMDYtMi43MTQgMS4wMTgtMy42MiAyLjI1NS0uOTEgMS4yNDEtMS42MDkgMi44MzUtMi4wNDIgNC41ODYtLjg2NiAzLjQ5OS0uNzAzIDcuNzU4IDIuMDU2IDEwLjU2IDEuNDYgMS40OTMgMy40MDQgMi4zNSA1LjI2NSAyLjg1IDEuMzIuMzU1IDIuNTMuNDc4IDMuNjI5LjUwOS42MDggNy4xMzMgNC43OTcgMTMuNDA2IDEwLjM5IDE2LjU1OWguMDAxYzIuOTg1IDEuNjc3IDYuMDg0IDIuNTM4IDguNzk5IDMuNTc3IDMuNDY4IDEuMzQgNi44MzQgMi42NDMgMTAuMzY2IDIuOTUybC4wNTguMDA2aC40MDVjMy43MDUgMCA3LjA3Ni0xLjY1NiAxMC40NzgtMi45NTYgMi43MS0xLjAzNyA1LjgxMi0xLjg3NiA4LjgwMi0zLjU1NiA1LjYyMy0zLjE1MiA5LjgxLTkuNDQgMTAuNDItMTYuNTcyIDIuNjc4LS4wNTIgNi4zNTYtLjgyOCA4Ljg0MS0zLjM2NyAyLjc2MS0yLjgwMiAyLjkyNS03LjA2MiAyLjA1OC0xMC41NjItLjQzMy0xLjc1LTEuMTMxLTMuMzQ1LTIuMDQxLTQuNTg2LS45MDctMS4yMzctMi4wODYtMi4yNS0zLjYyMS0yLjI1NWEzLjY4NCAzLjY4NCAwIDAgMC0uODYyLjAxNWMtLjYxNC4wODgtMS40Mi4zNDMtMi4zNDguOTE2LS44NDQuNTItMS4zNSAxLjI3My0xLjg2NSAyLjEwMi0uNTE2LjgzLS45OTcgMS43Ni0xLjQ3OCAyLjY1NS0uNDguODk0LS45NjQgMS43NS0xLjQyIDIuMzgyLS4wOTQuMTMtLjE3NC4xOTctLjI2NC4zMDMtNC42MTEtNi44Ny0xNC4wNDUtMTAuNS0yNi44Ni0xMC41eiIvPjxwYXRoIGQ9Ik00NS4xMyAwQzM0LjE3OCAwIDI0LjkyMiAyLjU1MSAxOC44NCA3LjkyOGMtLjE4NC0uMzI3LS4zMTktLjYxLS41My0uOTQ5LS42MzYtMS4wMjUtMS4yMzEtMi4xODktMy4xMS0zLjM0Ny0xLjMzMS0uODIzLTIuNjU3LTEuMjgyLTMuODEtMS40NS0uNTc0LS4wODItMS4yNDItLjA1NS0xLjc2OC0uMDA3bC4zNzEtLjA0N2MtMy40MTcgMC01LjQyMSAyLjA1LTYuNzE4IDMuODE4QzEuOTggNy43MTUgMS4xNDUgOS43LjYwNyAxMS44NzJjLTEuMDc1IDQuMzQzLTEuMDg4IDkuOTY1IDMuMDQgMTQuMTYgMi4xNjQgMi4yMDggNC43MDYgMy4yNDQgNy4wMDUgMy44Ni40NDMuMTE4LjgzNy4xNDggMS4yNjIuMjM2IDEuNDk5IDcuMTEgNS45MzYgMTMuMTIzIDExLjg3IDE2LjQ2N2wuMDAyLjAwMy4wMDQuMDAxYzMuNDkxIDEuOTYyIDYuODA2IDIuODYgOS4yOSAzLjgxIDMuNDc2IDEuMzQgNy4xNCAyLjgyMyAxMS40MTMgMy4xOTdsLjIyNC4wMmguNTY3YzQuOTA1IDAgOC42MjctMS45ODIgMTEuODQ2LTMuMjEyaC4wMDJjMi40Ni0uOTQyIDUuNzg4LTEuODE0IDkuMzA1LTMuNzlhMjMuMTM5IDIzLjEzOSAwIDAgMCA0LjQ5OC0zLjMwOSAyNS40MDMgMjUuNDAzIDAgMCAwIDcuMzkyLTEyLjk2MmMyLjcyNy0uNDY2IDUuNjItMS42NiA4LjIzLTQuMzIzIDQuMTI2LTQuMTk0IDQuMTE0LTkuODE2IDMuMDQtMTQuMTU4LS41MzktMi4xNzItMS4zNzMtNC4xNTctMi42Ny01LjkyNi0xLjI5Ni0xLjc2OS0zLjMtMy44MTgtNi43MTctMy44MThsLjM3OC4wNDhjLS41My0uMDQ4LTEuMi0uMDc2LTEuNzc1LjAwNy0xLjE1Mi4xNjgtMi40NzMuNjI4LTMuOCAxLjQ0OC0xLjg3MyAxLjE1NC0yLjQ3IDIuMzE1LTMuMTA1IDMuMzM2LS4yMDguMzM0LS4zNC42MTMtLjUyMi45MzZDNjUuMzA2IDIuNTQ2IDU2LjA2NSAwIDQ1LjEzIDB6bS4wODcgNS4xNWMxMy4zNjkgMCAyMi42MDIgNC4wMDMgMjYuNTI2IDExLjE2NSAyLjM2NC0uOTE3IDQuMTA3LTcuMTA1IDYuMDU2LTguMzA0IDEuNTc4LS45NzYgMi41MDEtLjczNSAyLjUwMS0uNzM1IDMuNTcxIDAgNy4yNSAxMC41MTMgMi42NzUgMTUuMTU0LTIuNDE4IDIuNDcxLTYuODgxIDMuMTY1LTkuMTA0IDIuOTg4LS4xNjggNy4xNjMtNC4zNDEgMTMuNjMtOS44NjIgMTYuNzI0LTIuODA5IDEuNTc4LTUuODMyIDIuNDA0LTguNjI3IDMuNDc0LTMuNDY0IDEuMzI1LTYuNzE1IDIuODY4LTEwLjAwNiAyLjg2OGgtLjM0N2MtMy4yNzctLjI4Ni02LjU0LTEuNTMtMTAuMDA1LTIuODY4LTIuNzk2LTEuMDctNS44MTgtMS45MTgtOC42MjctMy40OTYtNS40OS0zLjA5NS05LjY2Ni05LjU0Mi05LjgzNC0xNi43MDQtMi4yMDYuMTktNi43MTktLjQ5Ny05LjE1NS0yLjk4Ni00LjU3NC00LjY0LS44OTUtMTUuMTU0IDIuNjc2LTE1LjE1NCAwIDAgLjkyMy0uMjQxIDIuNTAxLjczNSAxLjk2IDEuMjA1IDMuNzEgNy40NTQgNi4wOTQgOC4zMTlDMjIuNTk3IDkuMTUgMzEuODM2IDUuMTUgNDUuMjE3IDUuMTV6Ii8+PHBhdGggZD0iTTQ3LjE0IDQwLjk5Yy45MDIgMCAxLjQyMy0uNTg0IDEuNDIzLTEuMzczIDAtMS4yMzktLjUyMi0xLjcxNC0xLjQxOC0xLjc4Ni0uMzItLjAyNi0uNTg0LjA2NS0uNjc0LjM0Ny0uMDkuMjgyLjA1NC42MzMuMzQ3LjY3NC42ODYuMDk3LjY4NS4yMTYuNjg1LjU2NiAwIC4zNDgtLjQwMi40OTQtLjQ4NS41MTNhLjUzNi41MzYgMCAwIDAgLjEyMSAxLjA1OG0tMy44MzMuMDAxYy0uOTAyIDAtMS40MjMtLjU4NC0xLjQyMy0xLjM3MyAwLTEuMjM5LjUyMS0xLjcxNCAxLjQxNy0xLjc4Ni4zMjEtLjAyNi41ODQuMDY1LjY3NS4zNDcuMDkuMjgyLS4wNTQuNjMzLS4zNDcuNjc0LS42ODYuMDk3LS42ODYuMjE2LS42ODYuNTY2IDAgLjM0OC40MDMuNDk0LjQ4Ni41MTNhLjUzNi41MzYgMCAwIDEtLjEyMiAxLjA1OG0xNi40NzYtMjcuMDgxYy02LjMzNiAwLTExLjQ3MiA1LjEzNy0xMS40NzIgMTEuNDczIDAgNi4zMzYgNS4xMzYgMTEuNDczIDExLjQ3MiAxMS40NzMgNi4zMzYgMCAxMS40NzMtNS4xMzcgMTEuNDczLTExLjQ3MyAwLTYuMzM2LTUuMTM3LTExLjQ3My0xMS40NzMtMTEuNDczem0tMS42MDYgNi40NGE1LjEgNS4xIDAgMCAxIDAgMTAuMTk3IDUuMDk4IDUuMDk4IDAgMCAxLTQuOTM4LTYuMzY3IDIuMTQ0IDIuMTQ0IDAgMSAwIDIuMDc0LTIuOTUgNS4wNzIgNS4wNzIgMCAwIDEgMi44NjQtLjg4em0tMjcuNTI1LTYuNDRjLTYuMzM2IDAtMTEuNDcyIDUuMTM3LTExLjQ3MiAxMS40NzMgMCA2LjMzNiA1LjEzNiAxMS40NzMgMTEuNDcyIDExLjQ3MyA2LjMzNiAwIDExLjQ3My01LjEzNyAxMS40NzMtMTEuNDczIDAtNi4zMzYtNS4xMzctMTEuNDczLTExLjQ3My0xMS40NzN6bTEuNjQgNi40NGE1LjEgNS4xIDAgMCAxIDAgMTAuMTk3IDUuMDk4IDUuMDk4IDAgMCAxLTQuOTM4LTYuMzY3IDIuMTQ0IDIuMTQ0IDAgMCAwIDQuMTI3LS44MSAyLjE0MiAyLjE0MiAwIDAgMC0yLjA1NC0yLjE0IDUuMDc0IDUuMDc0IDAgMCAxIDIuODY0LS44OHoiLz48L2c+PC9zdmc+"/>
 </svg>
@@ -157,11 +157,11 @@ exports[`test/badgen.spec.js TAP generate badge with { label, status, style } > 
     <rect fill="#555" width="349" height="200"/>
     <rect fill="#08C" x="349" width="455" height="200"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="249" fill="#000" opacity="0.1">npm</text>
-    <text x="50" y="138" textLength="249">npm</text>
+    <text x="50" y="138" textLength="249" fill="#fff">npm</text>
     <text x="404" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
-    <text x="394" y="138" textLength="355">v1.0.0</text>
+    <text x="394" y="138" textLength="355" fill="#fff">v1.0.0</text>
   </g>
   
 </svg>
@@ -180,11 +180,11 @@ exports[`test/badgen.spec.js TAP generate badge with { status, icon } > snapshot
     <rect width="324" height="200" fill="#08C" x="212"/>
     <rect width="536" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="172" y="148" textLength="0" fill="#000" opacity="0.25"></text>
-    <text x="162" y="138" textLength="0"></text>
+    <text x="162" y="138" textLength="0" fill="#fff"></text>
     <text x="267" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
-    <text x="257" y="138" textLength="224">icon</text>
+    <text x="257" y="138" textLength="224" fill="#fff">icon</text>
   </g>
   <image x="40" y="35" width="130" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9IiNGRkYiIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgPHBhdGggZD0iTTE2LjIxIDguNjlsNi43Mi0xLjY4QTEyLjAzIDEyLjAzIDAgMCAxIDI0IDExLjk3YTEyLjA5IDEyLjA5IDAgMCAxLTEyLjk0IDEybDQuOS04LjM1Yy4zNi0uMzguNjYtLjguODktMS4yN2E1LjQ1IDUuNDUgMCAwIDAtLjA1LTQuNzUgNS4xNiA1LjE2IDAgMCAwLS41OS0uOTF6bS0zLjI0IDguNTdsLTIuMTIgNi42OUExMi4wMiAxMi4wMiAwIDAgMSAyLjA0IDUuMjhsNC44MyA4LjM4Yy4xOC41NCAxLjEyIDIuNTggMy4wNyAzLjMyIDEgLjM5IDIuMDQuNDggMy4wMy4yOXptLTEtOS42NGE0LjUyIDQuNTIgMCAwIDAtNC4yOCAzLjUxIDQuNDggNC40OCAwIDAgMCAxLjI0IDQuMDMgNC40OSA0LjQ5IDAgMCAwIDQuNzMuOTMgNC40OSA0LjQ5IDAgMCAwIDIuNy0zLjQzIDQuNTMgNC41MyAwIDAgMC0yLjUtNC42MyA0LjQxIDQuNDEgMCAwIDAtMS44OS0uNDF6TTcuMDUgOS45NmwtNC44LTVBMTIuMDQgMTIuMDQgMCAwIDEgMTIgMGM0LjU2IDAgOC43NCAyLjYgMTAuNzcgNi42N0gxMi41NmE1LjU0IDUuNTQgMCAwIDAtNC4yNyAxLjQ2IDUuMzQgNS4zNCAwIDAgMC0xLjI0IDEuODN6Ii8+Cjwvc3ZnPgo="/>
 </svg>
@@ -203,11 +203,11 @@ exports[`test/badgen.spec.js TAP generate badge with { status, icon, iconWidth }
     <rect width="324" height="200" fill="#08C" x="272"/>
     <rect width="596" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="232" y="148" textLength="0" fill="#000" opacity="0.25"></text>
-    <text x="222" y="138" textLength="0"></text>
+    <text x="222" y="138" textLength="0" fill="#fff"></text>
     <text x="327" y="148" textLength="224" fill="#000" opacity="0.25">icon</text>
-    <text x="317" y="138" textLength="224">icon</text>
+    <text x="317" y="138" textLength="224" fill="#fff">icon</text>
   </g>
   <image x="40" y="35" width="190" height="130" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNDAuOTI1IiBoZWlnaHQ9IjIwMi42NzYiIHZpZXdCb3g9IjAgMCA5MC4yMDMgNTMuNjI1Ij48ZyBmaWxsPSIjZmZmIj48cGF0aCBvcGFjaXR5PSIuNDU2IiBkPSJNNDUuMjE2IDMuODI2Yy0xMi44MzYgMC0yMi4yOCAzLjYzNC0yNi44ODQgMTAuNTMxLS4wOTEtLjEwNi0uMTcxLS4xNzItLjI2Ni0uMzAyLS40NTktLjYyOS0uOTQ1LTEuNDg2LTEuNDI4LTIuMzg0LS40ODQtLjg5OC0uOTY3LTEuODM1LTEuNDg1LTIuNjctLjUxOC0uODM1LTEuMDI1LTEuNTkzLTEuODc0LTIuMTE2LS45MjctLjU3My0xLjczMy0uODI4LTIuMzQ3LS45MTZhMy42ODMgMy42ODMgMCAwIDAtLjg2Mi0uMDE1Yy0xLjUzNS4wMDYtMi43MTQgMS4wMTgtMy42MiAyLjI1NS0uOTEgMS4yNDEtMS42MDkgMi44MzUtMi4wNDIgNC41ODYtLjg2NiAzLjQ5OS0uNzAzIDcuNzU4IDIuMDU2IDEwLjU2IDEuNDYgMS40OTMgMy40MDQgMi4zNSA1LjI2NSAyLjg1IDEuMzIuMzU1IDIuNTMuNDc4IDMuNjI5LjUwOS42MDggNy4xMzMgNC43OTcgMTMuNDA2IDEwLjM5IDE2LjU1OWguMDAxYzIuOTg1IDEuNjc3IDYuMDg0IDIuNTM4IDguNzk5IDMuNTc3IDMuNDY4IDEuMzQgNi44MzQgMi42NDMgMTAuMzY2IDIuOTUybC4wNTguMDA2aC40MDVjMy43MDUgMCA3LjA3Ni0xLjY1NiAxMC40NzgtMi45NTYgMi43MS0xLjAzNyA1LjgxMi0xLjg3NiA4LjgwMi0zLjU1NiA1LjYyMy0zLjE1MiA5LjgxLTkuNDQgMTAuNDItMTYuNTcyIDIuNjc4LS4wNTIgNi4zNTYtLjgyOCA4Ljg0MS0zLjM2NyAyLjc2MS0yLjgwMiAyLjkyNS03LjA2MiAyLjA1OC0xMC41NjItLjQzMy0xLjc1LTEuMTMxLTMuMzQ1LTIuMDQxLTQuNTg2LS45MDctMS4yMzctMi4wODYtMi4yNS0zLjYyMS0yLjI1NWEzLjY4NCAzLjY4NCAwIDAgMC0uODYyLjAxNWMtLjYxNC4wODgtMS40Mi4zNDMtMi4zNDguOTE2LS44NDQuNTItMS4zNSAxLjI3My0xLjg2NSAyLjEwMi0uNTE2LjgzLS45OTcgMS43Ni0xLjQ3OCAyLjY1NS0uNDguODk0LS45NjQgMS43NS0xLjQyIDIuMzgyLS4wOTQuMTMtLjE3NC4xOTctLjI2NC4zMDMtNC42MTEtNi44Ny0xNC4wNDUtMTAuNS0yNi44Ni0xMC41eiIvPjxwYXRoIGQ9Ik00NS4xMyAwQzM0LjE3OCAwIDI0LjkyMiAyLjU1MSAxOC44NCA3LjkyOGMtLjE4NC0uMzI3LS4zMTktLjYxLS41My0uOTQ5LS42MzYtMS4wMjUtMS4yMzEtMi4xODktMy4xMS0zLjM0Ny0xLjMzMS0uODIzLTIuNjU3LTEuMjgyLTMuODEtMS40NS0uNTc0LS4wODItMS4yNDItLjA1NS0xLjc2OC0uMDA3bC4zNzEtLjA0N2MtMy40MTcgMC01LjQyMSAyLjA1LTYuNzE4IDMuODE4QzEuOTggNy43MTUgMS4xNDUgOS43LjYwNyAxMS44NzJjLTEuMDc1IDQuMzQzLTEuMDg4IDkuOTY1IDMuMDQgMTQuMTYgMi4xNjQgMi4yMDggNC43MDYgMy4yNDQgNy4wMDUgMy44Ni40NDMuMTE4LjgzNy4xNDggMS4yNjIuMjM2IDEuNDk5IDcuMTEgNS45MzYgMTMuMTIzIDExLjg3IDE2LjQ2N2wuMDAyLjAwMy4wMDQuMDAxYzMuNDkxIDEuOTYyIDYuODA2IDIuODYgOS4yOSAzLjgxIDMuNDc2IDEuMzQgNy4xNCAyLjgyMyAxMS40MTMgMy4xOTdsLjIyNC4wMmguNTY3YzQuOTA1IDAgOC42MjctMS45ODIgMTEuODQ2LTMuMjEyaC4wMDJjMi40Ni0uOTQyIDUuNzg4LTEuODE0IDkuMzA1LTMuNzlhMjMuMTM5IDIzLjEzOSAwIDAgMCA0LjQ5OC0zLjMwOSAyNS40MDMgMjUuNDAzIDAgMCAwIDcuMzkyLTEyLjk2MmMyLjcyNy0uNDY2IDUuNjItMS42NiA4LjIzLTQuMzIzIDQuMTI2LTQuMTk0IDQuMTE0LTkuODE2IDMuMDQtMTQuMTU4LS41MzktMi4xNzItMS4zNzMtNC4xNTctMi42Ny01LjkyNi0xLjI5Ni0xLjc2OS0zLjMtMy44MTgtNi43MTctMy44MThsLjM3OC4wNDhjLS41My0uMDQ4LTEuMi0uMDc2LTEuNzc1LjAwNy0xLjE1Mi4xNjgtMi40NzMuNjI4LTMuOCAxLjQ0OC0xLjg3MyAxLjE1NC0yLjQ3IDIuMzE1LTMuMTA1IDMuMzM2LS4yMDguMzM0LS4zNC42MTMtLjUyMi45MzZDNjUuMzA2IDIuNTQ2IDU2LjA2NSAwIDQ1LjEzIDB6bS4wODcgNS4xNWMxMy4zNjkgMCAyMi42MDIgNC4wMDMgMjYuNTI2IDExLjE2NSAyLjM2NC0uOTE3IDQuMTA3LTcuMTA1IDYuMDU2LTguMzA0IDEuNTc4LS45NzYgMi41MDEtLjczNSAyLjUwMS0uNzM1IDMuNTcxIDAgNy4yNSAxMC41MTMgMi42NzUgMTUuMTU0LTIuNDE4IDIuNDcxLTYuODgxIDMuMTY1LTkuMTA0IDIuOTg4LS4xNjggNy4xNjMtNC4zNDEgMTMuNjMtOS44NjIgMTYuNzI0LTIuODA5IDEuNTc4LTUuODMyIDIuNDA0LTguNjI3IDMuNDc0LTMuNDY0IDEuMzI1LTYuNzE1IDIuODY4LTEwLjAwNiAyLjg2OGgtLjM0N2MtMy4yNzctLjI4Ni02LjU0LTEuNTMtMTAuMDA1LTIuODY4LTIuNzk2LTEuMDctNS44MTgtMS45MTgtOC42MjctMy40OTYtNS40OS0zLjA5NS05LjY2Ni05LjU0Mi05LjgzNC0xNi43MDQtMi4yMDYuMTktNi43MTktLjQ5Ny05LjE1NS0yLjk4Ni00LjU3NC00LjY0LS44OTUtMTUuMTU0IDIuNjc2LTE1LjE1NCAwIDAgLjkyMy0uMjQxIDIuNTAxLjczNSAxLjk2IDEuMjA1IDMuNzEgNy40NTQgNi4wOTQgOC4zMTlDMjIuNTk3IDkuMTUgMzEuODM2IDUuMTUgNDUuMjE3IDUuMTV6Ii8+PHBhdGggZD0iTTQ3LjE0IDQwLjk5Yy45MDIgMCAxLjQyMy0uNTg0IDEuNDIzLTEuMzczIDAtMS4yMzktLjUyMi0xLjcxNC0xLjQxOC0xLjc4Ni0uMzItLjAyNi0uNTg0LjA2NS0uNjc0LjM0Ny0uMDkuMjgyLjA1NC42MzMuMzQ3LjY3NC42ODYuMDk3LjY4NS4yMTYuNjg1LjU2NiAwIC4zNDgtLjQwMi40OTQtLjQ4NS41MTNhLjUzNi41MzYgMCAwIDAgLjEyMSAxLjA1OG0tMy44MzMuMDAxYy0uOTAyIDAtMS40MjMtLjU4NC0xLjQyMy0xLjM3MyAwLTEuMjM5LjUyMS0xLjcxNCAxLjQxNy0xLjc4Ni4zMjEtLjAyNi41ODQuMDY1LjY3NS4zNDcuMDkuMjgyLS4wNTQuNjMzLS4zNDcuNjc0LS42ODYuMDk3LS42ODYuMjE2LS42ODYuNTY2IDAgLjM0OC40MDMuNDk0LjQ4Ni41MTNhLjUzNi41MzYgMCAwIDEtLjEyMiAxLjA1OG0xNi40NzYtMjcuMDgxYy02LjMzNiAwLTExLjQ3MiA1LjEzNy0xMS40NzIgMTEuNDczIDAgNi4zMzYgNS4xMzYgMTEuNDczIDExLjQ3MiAxMS40NzMgNi4zMzYgMCAxMS40NzMtNS4xMzcgMTEuNDczLTExLjQ3MyAwLTYuMzM2LTUuMTM3LTExLjQ3My0xMS40NzMtMTEuNDczem0tMS42MDYgNi40NGE1LjEgNS4xIDAgMCAxIDAgMTAuMTk3IDUuMDk4IDUuMDk4IDAgMCAxLTQuOTM4LTYuMzY3IDIuMTQ0IDIuMTQ0IDAgMSAwIDIuMDc0LTIuOTUgNS4wNzIgNS4wNzIgMCAwIDEgMi44NjQtLjg4em0tMjcuNTI1LTYuNDRjLTYuMzM2IDAtMTEuNDcyIDUuMTM3LTExLjQ3MiAxMS40NzMgMCA2LjMzNiA1LjEzNiAxMS40NzMgMTEuNDcyIDExLjQ3MyA2LjMzNiAwIDExLjQ3My01LjEzNyAxMS40NzMtMTEuNDczIDAtNi4zMzYtNS4xMzctMTEuNDczLTExLjQ3My0xMS40NzN6bTEuNjQgNi40NGE1LjEgNS4xIDAgMCAxIDAgMTAuMTk3IDUuMDk4IDUuMDk4IDAgMCAxLTQuOTM4LTYuMzY3IDIuMTQ0IDIuMTQ0IDAgMCAwIDQuMTI3LS44MSAyLjE0MiAyLjE0MiAwIDAgMC0yLjA1NC0yLjE0IDUuMDc0IDUuMDc0IDAgMCAxIDIuODY0LS44OHoiLz48L2c+PC9zdmc+"/>
 </svg>
@@ -225,9 +225,9 @@ exports[`test/badgen.spec.js TAP generate bare badge with { status } > snapshot 
     <rect width="470" height="200" fill="#08C" x="0"/>
     <rect width="470" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="65" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
-    <text x="55" y="138" textLength="355">v1.0.0</text>
+    <text x="55" y="138" textLength="355" fill="#fff">v1.0.0</text>
   </g>
 </svg>
 `
@@ -244,9 +244,9 @@ exports[`test/badgen.spec.js TAP generate bare badge with { status, color } > sn
     <rect width="470" height="200" fill="#ADF" x="0"/>
     <rect width="470" height="200" fill="url(#aaaaa)"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
-    <text x="65" y="148" textLength="355" fill="#000" opacity="0.25">v1.0.0</text>
-    <text x="55" y="138" textLength="355">v1.0.0</text>
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="65" y="148" textLength="355" fill="#fff" opacity="0.25">v1.0.0</text>
+    <text x="55" y="138" textLength="355" fill="#000">v1.0.0</text>
   </g>
 </svg>
 `
@@ -257,9 +257,9 @@ exports[`test/badgen.spec.js TAP generate bare badge with { status, style } > sn
   <g>
     <rect fill="#08C" x="0" width="470" height="200"/>
   </g>
-  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+  <g aria-hidden="true" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="65" y="148" textLength="355" fill="#000" opacity="0.1">v1.0.0</text>
-    <text x="55" y="138" textLength="355">v1.0.0</text>
+    <text x="55" y="138" textLength="355" fill="#fff">v1.0.0</text>
   </g>
 </svg>
 `


### PR DESCRIPTION
Closes #67

Hi! 👋 

This PR adds the logic to choose the text color based on the background color for each part of the badge. I adapted the logic from Shields.io but changed as little as possible, since the colors used by Badgen are slightly different. I also updated the documentation and the test snapshots.

Let me know what you think. Thanks!